### PR TITLE
Fix build_localy.sh

### DIFF
--- a/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -20,7 +20,7 @@
       {% endfor %}
     <li>{{ title }}</li>
   </ul>
-  {% if meta is defined and 'moveit1' in meta.viewkeys() %}
+  {% if meta is defined and 'moveit1' in meta.keys() %}
         {% include "moveit1_warning.html" %}
   {% endif %}
   <hr/>


### PR DESCRIPTION
### Description

This fixes issue #44 

According to the [python_documentation](https://docs.python.org/3.7/library/2to3.html?highlight=viewkeys#2to3fixer-dict) `dict.viewkeys()` has been changed to `dict.keys()` (which I found answered in this stack overflow question [here](https://stackoverflow.com/questions/57358384/python-dict-object-has-no-attribute-viewkeys))

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
