### PR TITLE
Enable travis to call htmlproofer.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ os: linux
 dist: bionic  # distro used by Travis, moveit_ci uses the docker image's distro
 services:
   - docker
-language: cpp
+language: ruby
+rvm:
+  - 2.7
 cache: ccache
 compiler: gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ deploy:
   # Add to Environment Variables section of Travis CI repository settings page
   github-token: $GITHUB_TOKEN
   # Only copy build output directory to gh-pages
-  local_dir: build/html
+  local_dir: build
   on:
     branch: main
     condition: $SCRIPT = htmlproofer.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ notifications:
 
 env:
   global:
+    - SCRIPT=.moveit_ci/travis.sh
     - MOVEIT_CI_TRAVIS_TIMEOUT=85  # Travis grants us 90 min, but we add a safety margin of 5 min
     - ROS_DISTRO=foxy
     - ROS_REPO=ros
@@ -33,7 +34,7 @@ before_script:
   - git clone -q -b ros2 --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
 
 script:
-  - .moveit_ci/travis.sh
+  ./$SCRIPT
 
 deploy:
   # Deploy to gh-pages branch

--- a/build_locally.sh
+++ b/build_locally.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 
-# Install rosdoc_lite if it isn't there yet
-test -x `which rosdoc_lite` || sudo apt install ros-$ROS_DISTRO-rosdoc-lite
-
 # Setup Environment
 rm -rf build
 
 # Build
-rosdoc_lite -o build .
+sphinx-build -W -b html . build
 
 # Run
-xdg-open ./build/html/index.html
+xdg-open ./build/index.html

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -31,12 +31,11 @@ source install/setup.bash
 cd ../$REPOSITORY_NAME
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
-sphinx-build -W -b html . native_build
-# Test build with ROS-version of Sphinx command so that it is generated same as ros.org
-rosdoc_lite -o build .
+sphinx-build -W -b html . build
+
 # Run HTML tests on generated build output to check for 404 errors, etc
-test "$TRAVIS_PULL_REQUEST" == false || URL_SWAP="--url-swap https\://github.com/ros-planning/moveit2_tutorials/blob/main/:file\://$PWD/build/html/"
-htmlproofer ./build --only-4xx --check-html --file-ignore ./build/html/genindex.html,./build/html/search.html --alt-ignore '/.*/' --url-ignore '#' $URL_SWAP
+test "$TRAVIS_PULL_REQUEST" == false || URL_SWAP="--url-swap https\://github.com/ros-planning/moveit2_tutorials/blob/main/:file\://$PWD/build/"
+htmlproofer ./build --only-4xx --check-html --file-ignore ./build/genindex.html,./build/search.html --alt-ignore '/.*/' --url-ignore '#' $URL_SWAP
 
 # Tell GitHub Pages (on deploy) to bypass Jekyll processing
-touch build/html/.nojekyll
+touch build/.nojekyll

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -5,13 +5,6 @@ set -e
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 export REPOSITORY_NAME=${PWD##*/}
 echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-sudo -E sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
-wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-sudo apt-get update -qq
-sudo apt-get install -qq -y python-rosdep python-wstool python3-colcon-common-extensions
-# Setup rosdep
-sudo rosdep init
-rosdep update
 # Install htmlpoofer
 gem update --system
 gem --version
@@ -19,16 +12,6 @@ gem install html-proofer
 # Install ROS's version of sphinx
 pip install sphinx==1.8.5
 sphinx-build --version
-cd ..
-mkdir -p ros_ws/src
-cd ros_ws/src
-git clone -b pr-foxy-devel https://github.com/MarqRazz/rosdoc_lite.git
-git clone -b pr-foxy-devel https://github.com/MarqRazz/genmsg.git
-cd ..
-rosdep install -r --from-paths . --ignore-src --rosdistro foxy -y
-colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release
-source install/setup.bash
-cd ../$REPOSITORY_NAME
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
 sphinx-build -W -b html . build

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -8,7 +8,7 @@ echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
 sudo -E sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
 wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 sudo apt-get update -qq
-sudo apt-get install -qq -y python-rosdep
+sudo apt-get install -qq -y python-rosdep python-wstool python3-colcon-common-extensions
 # Setup rosdep
 sudo rosdep init
 rosdep update
@@ -16,8 +16,19 @@ rosdep update
 gem update --system
 gem --version
 gem install html-proofer
-
-source /opt/ros/foxy/setup.bash
+# Install ROS's version of sphinx
+pip install sphinx==1.8.5
+sphinx-build --version
+cd ..
+mkdir -p ros_ws/src
+cd ros_ws/src
+git clone -b pr-foxy-devel https://github.com/MarqRazz/rosdoc_lite.git
+git clone -b pr-foxy-devel https://github.com/MarqRazz/genmsg.git
+cd ..
+rosdep install -r --from-paths . --ignore-src --rosdistro foxy -y
+colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release
+source install/setup.bash
+cd ../$REPOSITORY_NAME
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
 sphinx-build -W -b html . native_build

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -7,13 +7,3 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git
     version: foxy-devel
-  # TODO(marqrazz): Switch to upstream once PR has been created and merged
-  rosdoc_lite:
-    type: git
-    url: https://github.com/MarqRazz/rosdoc_lite.git
-    version: pr-foxy-devel
-  # TODO(marqrazz): Switch to upstream once PR has been created and merged
-  genmsg:
-    type: git
-    url: https://github.com/MarqRazz/genmsg.git
-    version: pr-foxy-devel


### PR DESCRIPTION
The PR re-orders the travis scrip to call `htmlproofer.sh`

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

