### PR TITLE
remove dependencies on rosdoc-lite to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ deploy:
   # Add to Environment Variables section of Travis CI repository settings page
   github-token: $GITHUB_TOKEN
   # Only copy build output directory to gh-pages
-  local_dir: build/html
+  local_dir: build
   on:
     branch: main
     condition: $SCRIPT = htmlproofer.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - MOVEIT_CI_TRAVIS_TIMEOUT=85  # Travis grants us 90 min, but we add a safety margin of 5 min
     - ROS_DISTRO=foxy
     - ROS_REPO=ros
-    - UPSTREAM_WORKSPACE="https://github.com/ros-planning/moveit2"
+    - UPSTREAM_WORKSPACE="moveit2_tutorials.repos, moveit2.repos"
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
     - WARNINGS_OK=false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - MOVEIT_CI_TRAVIS_TIMEOUT=85  # Travis grants us 90 min, but we add a safety margin of 5 min
     - ROS_DISTRO=foxy
     - ROS_REPO=ros
-    - UPSTREAM_WORKSPACE="moveit2_tutorials.repos, moveit2.repos"
+    - UPSTREAM_WORKSPACE="https://github.com/ros-planning/moveit2"
     - CXXFLAGS="-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
     - WARNINGS_OK=false
 

--- a/build_locally.sh
+++ b/build_locally.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 
-# Install rosdoc_lite if it isn't there yet
-test -x `which rosdoc_lite` || sudo apt install ros-$ROS_DISTRO-rosdoc-lite
-
 # Setup Environment
 rm -rf build
 
 # Build
-rosdoc_lite -o build .
+sphinx-build -W -b html . build
 
 # Run
-xdg-open ./build/html/index.html
+xdg-open ./build/index.html

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -5,27 +5,17 @@ set -e
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 export REPOSITORY_NAME=${PWD##*/}
 echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-sudo -E sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
-wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-sudo apt-get update -qq
-sudo apt-get install -qq -y python-rosdep
-# Setup rosdep
-sudo rosdep init
-rosdep update
-# Install htmlpoofer
-gem update --system
-gem --version
-gem install html-proofer
 
-source /opt/ros/foxy/setup.bash
+sudo gem update --system
+gem --version
+sudo gem install html-proofer
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
-sphinx-build -W -b html . native_build
-# Test build with ROS-version of Sphinx command so that it is generated same as ros.org
-rosdoc_lite -o build .
+sphinx-build -W -b html . build
+
 # Run HTML tests on generated build output to check for 404 errors, etc
-test "$TRAVIS_PULL_REQUEST" == false || URL_SWAP="--url-swap https\://github.com/ros-planning/moveit2_tutorials/blob/main/:file\://$PWD/build/html/"
-htmlproofer ./build --only-4xx --check-html --file-ignore ./build/html/genindex.html,./build/html/search.html --alt-ignore '/.*/' --url-ignore '#' $URL_SWAP
+test "$TRAVIS_PULL_REQUEST" == false || URL_SWAP="--url-swap https\://github.com/ros-planning/moveit2_tutorials/blob/main/:file\://$PWD/build/"
+htmlproofer ./build --only-4xx --check-html --file-ignore ./build/genindex.html,./build/search.html --alt-ignore '/.*/' --url-ignore '#' $URL_SWAP
 
 # Tell GitHub Pages (on deploy) to bypass Jekyll processing
-touch build/html/.nojekyll
+touch build/.nojekyll

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -1,8 +1,4 @@
 repositories:
-  moveit2_tutorials:
-    type: git
-    url: https://github.com/ros-planning/moveit2_tutorials.git
-    version: main
   rviz_visual_tools:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
### Description

Build directly with the sphinx script. Removes the dependency on rosdoc-lite, which isn't being maintained.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
