### PR TITLE
Enable building only main branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ compiler: gcc
 notifications:
   email: true
 
+branches:
+  only:
+    - main
+
 env:
   global:
     - SCRIPT=.moveit_ci/travis.sh


### PR DESCRIPTION
### Description

We need to enable `Build pushed branches` from Travis to deploy the website on new commits, this PR will restrict the deployment to only use the main branch

- [x] Enable `Build pushed branches` from [Travis settings](https://travis-ci.com/github/ros-planning/moveit2_tutorials/settings)