### PR TITLE
Adds git clone ros-planning/moveit2.git to install

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -33,7 +33,7 @@ You will need to have a `colcon <https://docs.ros.org/en/foxy/Tutorials/Colcon-T
 
   mkdir -p ~/ws_moveit2/src
   cd ~/ws_moveit2/src
- 
+
   git clone https://github.com/ros-planning/moveit2.git
   wget https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos
   vcs import < moveit2.repos

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -32,7 +32,7 @@ These tutorials rely on the master branch of MoveIt2, which requires a build fro
 You will need to have a `colcon <https://docs.ros.org/en/foxy/Tutorials/Colcon-Tutorial.html#install-colcon>`_ workspace setup: ::
 
   mkdir -p ~/ws_moveit2/src
-  cd ~/ws_moveit2/src 
+  cd ~/ws_moveit2/src
   
   git clone https://github.com/ros-planning/moveit2.git
   wget https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -32,8 +32,9 @@ These tutorials rely on the master branch of MoveIt2, which requires a build fro
 You will need to have a `colcon <https://docs.ros.org/en/foxy/Tutorials/Colcon-Tutorial.html#install-colcon>`_ workspace setup: ::
 
   mkdir -p ~/ws_moveit2/src
-  cd ~/ws_moveit2/src
-
+  cd ~/ws_moveit2/src 
+  
+  git clone https://github.com/ros-planning/moveit2.git
   wget https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos
   vcs import < moveit2.repos
   wget https://raw.githubusercontent.com/ros-planning/moveit2_tutorials/main/moveit2_tutorials.repos

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -33,7 +33,7 @@ You will need to have a `colcon <https://docs.ros.org/en/foxy/Tutorials/Colcon-T
 
   mkdir -p ~/ws_moveit2/src
   cd ~/ws_moveit2/src
-  
+ 
   git clone https://github.com/ros-planning/moveit2.git
   wget https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos
   vcs import < moveit2.repos


### PR DESCRIPTION
### Description

adds missing step to Foxy source install instructions: https://github.com/ros-planning/moveit2/issues/438#issuecomment-826421039 @tylerjw

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
