### PR TITLE
Fixed async call that was supposed to be synchronous in planning_scene_ros_api_tutorial.cpp

### DIFF
--- a/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
+++ b/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
@@ -177,14 +177,20 @@ int main(int argc, char** argv)
   // wait for the service to respond
   std::chrono::seconds wait_time(3);
   std::future_status fs = response_future.wait_for(wait_time);
-  if (fs == std::future_status::timeout) {
+  if (fs == std::future_status::timeout)
+  {
     RCLCPP_WARN(LOGGER, "Service timed out.");
-  } else {
+  }
+  else
+  {
     std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene_Response> planning_response;
     planning_response = response_future.get();
-    if (planning_response->success) {
+    if (planning_response->success)
+    {
       RCLCPP_INFO(LOGGER, "Service successfully added object.");
-    } else {
+    }
+    else
+    {
       RCLCPP_WARN(LOGGER, "Service failed to add object.");
     }
   }

--- a/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
+++ b/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
@@ -175,11 +175,11 @@ int main(int argc, char** argv)
   response_future = planning_scene_diff_client->async_send_request(request);
 
   // wait for the service to respond
-  std::chrono::seconds wait_time(3);
+  std::chrono::seconds wait_time(1);
   std::future_status fs = response_future.wait_for(wait_time);
   if (fs == std::future_status::timeout)
   {
-    RCLCPP_WARN(LOGGER, "Service timed out.");
+    RCLCPP_ERROR(LOGGER, "Service timed out.");
   }
   else
   {
@@ -191,7 +191,7 @@ int main(int argc, char** argv)
     }
     else
     {
-      RCLCPP_WARN(LOGGER, "Service failed to add object.");
+      RCLCPP_ERROR(LOGGER, "Service failed to add object.");
     }
   }
 


### PR DESCRIPTION
In the planning scene ROS API tutorial, the text states that updates to the planning scene can be made synchronously, then gives an asynchronous example. Changed the example to use a synchronous update.