### PR TITLE
Add git clone moveit2_tutorials in getting_started.rst

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -36,9 +36,8 @@ You will need to have a `colcon <https://docs.ros.org/en/foxy/Tutorials/Colcon-T
 
   git clone https://github.com/ros-planning/moveit2.git
   git clone https://github.com/ros-planning/moveit2_tutorials.git
-  wget https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos
-  vcs import < moveit2.repos
-  wget https://raw.githubusercontent.com/ros-planning/moveit2_tutorials/main/moveit2_tutorials.repos
+  vcs import < moveit2/moveit2.repos
+  vcs import < moveit2_tutorials/moveit2_tutorials.repos
   vcs import < moveit2_tutorials.repos
 
 Build your Colcon Workspace

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -44,7 +44,6 @@ Build your Colcon Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The following will install from Debian any package dependencies not already in your workspace: ::
 
-  cd ~/ws_moveit2/src
   rosdep install -r --from-paths . --ignore-src --rosdistro foxy -y
 
 The next command will configure your colcon workspace: ::

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -35,6 +35,7 @@ You will need to have a `colcon <https://docs.ros.org/en/foxy/Tutorials/Colcon-T
   cd ~/ws_moveit2/src
 
   git clone https://github.com/ros-planning/moveit2.git
+  git clone https://github.com/ros-planning/moveit2_tutorials.git
   wget https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos
   vcs import < moveit2.repos
   wget https://raw.githubusercontent.com/ros-planning/moveit2_tutorials/main/moveit2_tutorials.repos


### PR DESCRIPTION
### Description

Adds a git clone command for moveit2_tutorials on the getting started page. The [first tutorial](http://moveit2_tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html#step-1-launch-the-demo-and-configure-the-plugin) references this package, but it wouldn't be available based on the current instructions (assuming I didn't make a mistake).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
