### PR TITLE
Update getting_started.rst

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -38,7 +38,6 @@ You will need to have a `colcon <https://docs.ros.org/en/foxy/Tutorials/Colcon-T
   git clone https://github.com/ros-planning/moveit2_tutorials.git
   vcs import < moveit2/moveit2.repos
   vcs import < moveit2_tutorials/moveit2_tutorials.repos
-  vcs import < moveit2_tutorials.repos
 
 Build your Colcon Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
"vcs import < moveit2_tutorials.repos" can't be executed! Is this a typo?

### Description

The line i removed seems to be a typo, because there is no moveit2_tutorials.repo directly under "src". 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
