### PR TITLE
Draw attention to return value of MoveGroupInterface::setJointValueTarget

### DIFF
--- a/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -188,7 +188,8 @@ int main(int argc, char** argv)
   // Now, let's modify one of the joints, plan to the new joint space goal, and visualize the plan.
   joint_group_positions[0] = -1.0;  // radians
   bool within_bounds = move_group.setJointValueTarget(joint_group_positions);
-  if(!within_bounds) {
+  if (!within_bounds)
+  {
     RCLCPP_WARN(LOGGER, "Target joint position(s) were outside of limits, but we will plan and clamp to the limits ");
   }
 

--- a/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -187,7 +187,10 @@ int main(int argc, char** argv)
 
   // Now, let's modify one of the joints, plan to the new joint space goal, and visualize the plan.
   joint_group_positions[0] = -1.0;  // radians
-  move_group.setJointValueTarget(joint_group_positions);
+  bool within_bounds = move_group.setJointValueTarget(joint_group_positions);
+  if(!within_bounds) {
+    RCLCPP_WARN(LOGGER, "Target joint position(s) were outside of limits, but we will plan and clamp to the limits ");
+  }
 
   // We lower the allowed maximum velocity and acceleration to 5% of their maximum.
   // The default values are 10% (0.1).


### PR DESCRIPTION
### Description

This updates the tutorial to make users aware the existence and role of the MoveGroupInterface::setJointValueTarget boolean return.

Move group currently will allow setJointValueTarget to set a joint target outside of joint limits and MoveGroupInterface::plan will return a success (with a warning of "Joint <> is constrained to be above the maximum bounds. Assuming maximum bounds instead."). This is unexpected behavior by some users and this update to the tutorial will make it more clear where they should check to catch this kind of behavior.

It also makes a small clarification to the xterm usage.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
