### PR TITLE
Fixed broken link to launch file

### DIFF
--- a/doc/move_group_interface/move_group_interface_tutorial.rst
+++ b/doc/move_group_interface/move_group_interface_tutorial.rst
@@ -57,7 +57,7 @@ The entire code can be seen :codedir:`here in the MoveIt GitHub project<move_gro
 
 The Launch File
 ---------------
-The entire launch file is :codedir:`here<move_group_interface/launch/move_group_interface_tutorial.launch>` on GitHub. All the code in this tutorial can be run from the **moveit_tutorials** package that you have as part of your MoveIt setup.
+The entire launch file is :codedir:`here<move_group_interface/launch/move_group_interface_tutorial.launch.py>` on GitHub. All the code in this tutorial can be run from the **moveit_tutorials** package that you have as part of your MoveIt setup.
 
 
 A Note on Setting Tolerances


### PR DESCRIPTION
### Description

The launch file link to the repo was just missing the ".py".

### Checklist
- [ x ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ x ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
