### PR TITLE
Fix parameter names on Servo Teleop Demo: StaticTransformBroadcasterNode

### DIFF
--- a/doc/realtime_servo/launch/servo_teleop.launch.py
+++ b/doc/realtime_servo/launch/servo_teleop.launch.py
@@ -111,7 +111,7 @@ def generate_launch_description():
                 package="tf2_ros",
                 plugin="tf2_ros::StaticTransformBroadcasterNode",
                 name="static_tf2_broadcaster",
-                parameters=[{"/child_frame_id": "panda_link0", "/frame_id": "world"}],
+                parameters=[{"child_frame_id": "/panda_link0", "frame_id": "/world"}],
             ),
             ComposableNode(
                 package="moveit_servo",


### PR DESCRIPTION
### Description
The `/`'s on the parameter names broke the parameters and caused the Static TF publisher to use default values, which broke the TF tree. See attached. Now the Servo demo launches with the `/world` frame known in the TF tree

Before:
[frames_sad.pdf](https://github.com/ros-planning/moveit2_tutorials/files/6976654/frames_sad.pdf)

After:
[frames_happy.pdf](https://github.com/ros-planning/moveit2_tutorials/files/6976657/frames_happy.pdf)

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
