### PR TITLE
Add missing depdendencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -42,6 +42,7 @@
   <!-- <exec_depend>franka_description</exec_depend> -->
   <!-- <exec_depend>moveit_commander</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
+  <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -49,7 +49,6 @@
   <exec_depend>joy</exec_depend>
   <exec_depend>moveit</exec_depend>
   <exec_depend>moveit_resources_panda_moveit_config</exec_depend>
-  <exec_depend>position_controllers</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>warehouse_ros_mongo</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -40,12 +40,18 @@
   <build_depend>moveit_ros_planning</build_depend>
 
   <!-- <exec_depend>franka_description</exec_depend> -->
-  <exec_depend>joint_state_publisher</exec_depend>
-  <exec_depend>joy</exec_depend>
   <!-- <exec_depend>moveit_commander</exec_depend> -->
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>joy</exec_depend>
+  <exec_depend>moveit</exec_depend>
   <exec_depend>moveit_resources_panda_moveit_config</exec_depend>
+  <exec_depend>position_controllers</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
+  <exec_depend>warehouse_ros_mongo</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
### Description

These dependencies had to be installed when I tried doing the first tutorial without installing moveit from source and instead using rosdep to install dependencies of this package.