### PR TITLE
Migrate to joint state broadcaster

### DIFF
--- a/doc/move_group_interface/launch/move_group.launch.py
+++ b/doc/move_group_interface/launch/move_group.launch.py
@@ -162,7 +162,7 @@ def generate_launch_description():
     for controller in [
         "panda_arm_controller",
         "panda_hand_controller",
-        "joint_state_controller",
+        "joint_state_broadcaster",
     ]:
         load_controllers += [
             ExecuteProcess(

--- a/doc/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
+++ b/doc/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
@@ -146,7 +146,7 @@ def generate_launch_description():
     for controller in [
         "panda_arm_controller",
         "panda_hand_controller",
-        "joint_state_controller",
+        "joint_state_broadcaster",
     ]:
         load_controllers += [
             ExecuteProcess(

--- a/doc/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/quickstart_in_rviz/launch/demo.launch.py
@@ -186,7 +186,7 @@ def generate_launch_description():
     for controller in [
         "panda_arm_controller",
         "panda_hand_controller",
-        "joint_state_controller",
+        "joint_state_broadcaster",
     ]:
         load_controllers += [
             ExecuteProcess(

--- a/doc/realtime_servo/launch/servo_cpp_interface_demo.launch.py
+++ b/doc/realtime_servo/launch/servo_cpp_interface_demo.launch.py
@@ -111,7 +111,7 @@ def generate_launch_description():
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],

--- a/doc/realtime_servo/launch/servo_server_panda.launch.py
+++ b/doc/realtime_servo/launch/servo_server_panda.launch.py
@@ -87,7 +87,7 @@ def generate_launch_description():
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],

--- a/doc/realtime_servo/launch/servo_teleop.launch.py
+++ b/doc/realtime_servo/launch/servo_teleop.launch.py
@@ -85,7 +85,7 @@ def generate_launch_description():
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],

--- a/package.xml
+++ b/package.xml
@@ -43,7 +43,7 @@
   <!-- <exec_depend>moveit_commander</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>gripper_controllers</exec_depend>
-  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joy</exec_depend>


### PR DESCRIPTION
With ros-controls/ros2_controllers#230 ros2_control now removed joint_state_controller in favor of joint_state_broadcaster. This PR migrates our main branch to joint_state_broadcaster. Depends on ros-planning/moveit_resources#96.