### PR TITLE
Clone repository ros-planning/moveit_resources to fix issue #114

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -3,7 +3,6 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools
     version: foxy-devel
-
   moveit_resources:
     type: git
     url: https://github.com/ros-planning/moveit_resources

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -3,3 +3,8 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools
     version: foxy-devel
+
+  moveit_resources:
+    type: git
+    url: https://github.com/ros-planning/moveit_resources
+    version: ros2


### PR DESCRIPTION
Potentially fixes issue #114

### Description

Currently, in Foxy, the repositories **moveit2_tutorials** and   **moveit_resources** are out of synch.

A more conservative approach would be to add this repository to **moveit2_tutorials.repos**

