### PR TITLE
No longer require xterm

### DIFF
--- a/doc/move_group_interface/move_group_interface_tutorial.rst
+++ b/doc/move_group_interface/move_group_interface_tutorial.rst
@@ -12,11 +12,6 @@ Getting Started
 ---------------
 If you haven't already done so, make sure you've completed the steps in `Getting Started <../getting_started/getting_started.html>`_.
 
-**Note:** Because **MoveitVisualTools** has not been ported to ROS2 this tutoral has made use of xterm and a simple prompter to help the user progress through each demo step.
-To install xterm please run the following command: ::
-
-   sudo apt-get install -y xterm
-
 Running the Code
 ----------------
 Open two shells. In the first shell start RViz and wait for everything to finish loading: ::
@@ -26,9 +21,6 @@ Open two shells. In the first shell start RViz and wait for everything to finish
 In the second shell, run the launch file: ::
 
   ros2 launch moveit2_tutorials move_group_interface_tutorial.launch.py
-
-**Note:** RvizVisualToolsGui panel has not been ported to ROS2 yet
-This tutorial uses the **RvizVisualToolsGui** panel to step through the demo. To add this panel to RViz, follow the instructions in the `Visualization Tutorial <../quickstart_in_rviz/quickstart_in_rviz_tutorial.html#rviz-visual-tools>`_.
 
 After a short moment, the RViz window should appear and look similar to the one at the top of this page. To progress through each demo step either press the **Next** button in the **RvizVisualToolsGui** panel at the bottom of the screen or select **Key Tool** in the **Tools** panel at the top of the screen and then press **N** on your keyboard while RViz is focused.
 


### PR DESCRIPTION
### Description

As the next button now works in the rviz_visual_tools, we no longer need these sections of the instructions.