### PR TITLE
Fix references to package to moveit2_tutorials

### DIFF
--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -138,7 +138,7 @@
            <div itemprop="articleBody">
              <!-- <div class="admonition note">  -->
                <!-- <p class="first admonition-title">Code Used in this Tutorial Available</p>  -->
-               <!-- <p class="last">Code can be found at <a href = "https://github.com/ros-planning/moveit_tutorials">moveit_tutorials repository</a> in doc folder. Use master branch.</p> -->
+               <!-- <p class="last">Code can be found at <a href = "https://github.com/ros-planning/moveit2_tutorials">moveit2_tutorials repository</a> in doc folder. Use master branch.</p> -->
              <!-- </div>  -->
             {% block body %}{% endblock %}
             {% if display_github %}

--- a/doc/move_group_interface/move_group_interface_tutorial.rst
+++ b/doc/move_group_interface/move_group_interface_tutorial.rst
@@ -49,7 +49,7 @@ The entire code can be seen :codedir:`here in the MoveIt GitHub project<move_gro
 
 The Launch File
 ---------------
-The entire launch file is :codedir:`here<move_group_interface/launch/move_group_interface_tutorial.launch.py>` on GitHub. All the code in this tutorial can be run from the **moveit_tutorials** package that you have as part of your MoveIt setup.
+The entire launch file is :codedir:`here<move_group_interface/launch/move_group_interface_tutorial.launch.py>` on GitHub. All the code in this tutorial can be run from the **moveit2_tutorials** package that you have as part of your MoveIt setup.
 
 
 A Note on Setting Tolerances


### PR DESCRIPTION
### Description

This fixes the name of the package in a couple places to be moveit2_tutorials.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
