### PR TITLE
Add moveit_cpp subdirectory to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,12 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
 
 add_subdirectory(doc/move_group_interface)
+add_subdirectory(doc/moveit_cpp)
 add_subdirectory(doc/planning_scene)
 add_subdirectory(doc/planning_scene_ros_api)
 add_subdirectory(doc/quickstart_in_rviz)
-add_subdirectory(doc/robot_model_and_robot_state)
 add_subdirectory(doc/realtime_servo)
+add_subdirectory(doc/robot_model_and_robot_state)
 
 ament_export_dependencies(
   ${THIS_PACKAGE_INCLUDE_DEPENDS}


### PR DESCRIPTION
### Description

Without this the directory doesn't build and therefore the tutorial is broken.  This also sorts the calls to add_subdirectory.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
