### PR TITLE
Do not run the Galactic CI job on main branch

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         env:
-          - IMAGE: galactic-source
           - IMAGE: rolling-source
 
     env:


### PR DESCRIPTION
I don't really know what I'm doing with CI so please double-check this.

I just created a Galactic branch. Thus, Galactic CI should not be running for the main branch anymore. I hope this removes it.