### PR TITLE
Add mergify for backporting PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,26 @@
+pull_request_rules:
+  - name: backport to galactic at reviewers discretion
+    conditions:
+      - base=main
+      - "label=backport-galactic"
+    actions:
+      backport:
+        branches:
+          - galactic
+
+  - name: backport to foxy at reviewers discretion
+    conditions:
+      - base=main
+      - "label=backport-foxy"
+    actions:
+      backport:
+        branches:
+          - foxy
+
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+      - author!=mergify
+    actions:
+        comment:
+          message: This pull request is in conflict. Could you fix it @{{author}}?


### PR DESCRIPTION
@henningkayser and I talked recently about trying out mergify for backporting (which is already enabled on ros-planning organization), this PR adds mergify to main branch, then we can use mergify to backport mergify in the other branches 😆. For that can we have backport-galactic and backport-foxy labels for that @henningkayser?