### PR TITLE
Fix response future type

### DIFF
--- a/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
+++ b/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv)
   auto request = std::make_shared<moveit_msgs::srv::ApplyPlanningScene::Request>();
   request->scene = planning_scene;
   std::shared_future<std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene_Response>> response_future;
-  response_future = planning_scene_diff_client->async_send_request(request).future.share();
+  response_future = planning_scene_diff_client->async_send_request(request);
 
   // wait for the service to respond
   std::chrono::seconds wait_time(1);


### PR DESCRIPTION
### Description

I've tested this fixing this error on galactic.  It needs to be also tested on rolling:

```
--- stderr: moveit2_tutorials                                                                                             
/home/tyler/code/m2/ws_tutorial/src/moveit2_tutorials/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp: In function ‘int main(int, char**)’:
/home/tyler/code/m2/ws_tutorial/src/moveit2_tutorials/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp:164:77: error: ‘using SharedFuture = class std::shared_future<std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene_Response_<std::allocator<void> > > >’ {aka ‘class std::shared_future<std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene_Response_<std::allocator<void> > > >’} has no member named ‘future’
  164 |   response_future = planning_scene_diff_client->async_send_request(request).future.share();
      |                                                                             ^~~~~~
make[2]: *** [doc/planning_scene_ros_api/CMakeFiles/planning_scene_ros_api_tutorial.dir/build.make:63: doc/planning_scene_ros_api/CMakeFiles/planning_scene_ros_api_tutorial.dir/src/planning_scene_ros_api_tutorial.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:332: doc/planning_scene_ros_api/CMakeFiles/planning_scene_ros_api_tutorial.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:141: all] Error 2
---
Failed   <<< moveit2_tutorials [21.1s, exited with code 2]
```

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
