### PR TITLE
change base url and cname to moveit.picknik.ai

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,4 +43,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/html
-        cname: moveit2_tutorials.picknik.ai
+        cname: moveit.picknik.ai

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **NOTE: This repository is a new fork from the [MoveIt 1 tutorials](https://ros-planning.github.io/moveit_tutorials/) and needs your help with porting old tutorials to ROS 2.** To claim a tutorial to support the port of, see the Issues list. Thanks!
 
-[See the live MoveIt 2 tutorials here](http://moveit2_tutorials.picknik.ai/)
+[See the live MoveIt 2 tutorials here](https://moveit.picknik.ai/)
 
 This is the primary documentation for the MoveIt project. We strongly encourage you to help improve MoveIt's documentation. Please consider reading the guidelines below for writing the best documentation and tutorials. However, if you are uncomfortable with any of the approaches, simply adding documentation text to your pull requests is better than nothing.
 
@@ -17,7 +17,7 @@ This repository is currently built automatically by Github Actions:
 - foxy: [![Build](https://github.com/ros-planning/moveit2_tutorials/actions/workflows/ci_main.yml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2_tutorials/actions/workflows/ci_foxy.yml?query=branch%3Afoxy) (Foxy)
 - foxy: [![Format](https://github.com/ros-planning/moveit2_tutorials/actions/workflows/format.yml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2_tutorials/actions/workflows/format.yml?query=branch%3Afoxy) (Foxy)
 - foxy: [![Deploy](https://github.com/ros-planning/moveit2_tutorials/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/ros-planning/moveit2_tutorials/actions/workflows/deploy.yml?query=branch%3Afoxy) (Foxy)
-- foxy: [Github Pages](https://moveit2_tutorials.picknik.ai/): (Foxy)
+- foxy: [Github Pages](https://moveit.picknik.ai/): (Foxy)
 
 ## Helping with Porting Tutorials to ROS 2
 An issue has been created for each tutorial to be ported to Foxy. At the top of each tutorial there is a tag: ":moveit1:", remove the tag

--- a/conf.py
+++ b/conf.py
@@ -162,7 +162,7 @@ html_sourcelink_suffix = ""
 # Output file base name for HTML help builder.
 htmlhelp_basename = "MoveItDocumentation"
 
-html_baseurl = "https://moveit2_tutorials.picknik.ai/"
+html_baseurl = "https://moveit.picknik.ai/"
 
 # Add any paths that contain custom themes here, relative to this directory.
 

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <maintainer email="dave@picknik.ai">Dave Coleman</maintainer>
   <maintainer email="mike@picknik.ai">Mike Lautman</maintainer>
 
-  <url type="website">https://moveit2_tutorials.picknik.ai</url>
+  <url type="website">https://moveit.picknik.ai</url>
   <url type="repository">https://github.com/ros-planning/moveit2_tutorials</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit2_tutorials/issues</url>
 


### PR DESCRIPTION
### Description

Updated the URL to point to `moveit.picknik.ai`. This should fix the ssl cert issue.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
