### PR TITLE
Disable 429 errors

### DIFF
--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -20,7 +20,7 @@ rm -rf build
 sphinx-build -W -b html . build
 
 # Run HTML tests on generated build output to check for 404 errors, etc
-htmlproofer ./build --only-4xx --check-html --file-ignore ./build/genindex.html,./build/search.html --alt-ignore '/.*/' --url-ignore '#' --url-swap 'https\://github.com/ros-planning/moveit2_tutorials/blob/main/:file\://$PWD/build/' --url-swap 'https\://moveit.picknik.ai/rolling:file\://$PWD/build/'
+htmlproofer ./build --only-4xx --check-html --http-status-ignore "429" --file-ignore ./build/genindex.html,./build/search.html --alt-ignore '/.*/' --url-ignore '#' --url-swap 'https\://github.com/ros-planning/moveit2_tutorials/blob/main/:file\://$PWD/build/' --url-swap 'https\://moveit.picknik.ai/rolling:file\://$PWD/build/'
 
 # Tell GitHub Pages (on deploy) to bypass Jekyll processing
 touch build/.nojekyll


### PR DESCRIPTION
We are having flaky 429 errors (too many requests) from Github links, which are irrelevant and seems like a Github issue. This PR will ignore 429 errors.