### PR TITLE
Use foxy branch for moveit_visual_tools

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -10,4 +10,4 @@ repositories:
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools
-    version: ros2
+    version: foxy


### PR DESCRIPTION
ros2 branch of mvt will not compile on foxy any more after the last changes, and all the foxy builds of tutorials will fail. We should use the foxy branch of moveit_visual_tools from now on for Foxy builds.