### PR TITLE
:fire: Development branch banner

### DIFF
--- a/_templates/page.html
+++ b/_templates/page.html
@@ -22,7 +22,7 @@
 {% block body %}
 {% if current_version and latest_version and current_version != latest_version %}
 <p>
-  <strong style="color: red;">
+  <strong>
     {% if current_version.name|string() in eol_versions %}
     You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
     If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
@@ -30,8 +30,7 @@
     You're reading the documentation for an older, but still supported, version of ROS 2.
     For information on the latest version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% else %}
-    You're reading the documentation for an untested version of the tutorials that is largely a copy of the tutorials from MoveIt on ROS 1 Noetic.
-    This is here because it contains useful information, albeit incomplete and often misleading.
+    You're reading the documentation for a development version.
     For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
     {% endif %}
   </strong>


### PR DESCRIPTION
### Description

This puts back the development version banner to the tutorials website now that it has been refactored to hide all the not-yet-ported pieces in the Examples section.