### PR TITLE
:fire: Fix embeded video

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ To embed a video that is included in this repository, you also will use raw html
 .. raw:: html
 
     <video width="700px" controls="true" autoplay="true" loop="true">
-        <source src="/_static/videos/rviz_joints_nullspace.webm" type="video/webm">
+        <source src="../../../_static/videos/rviz_joints_nullspace.webm" type="video/webm">
         The joints moving while the end effector stays still
     </video>
 ```

--- a/doc/examples/mobile_base_arm/mobile_base_arm_tutorial.rst
+++ b/doc/examples/mobile_base_arm/mobile_base_arm_tutorial.rst
@@ -107,14 +107,14 @@ Open a shell and start RViz and wait for everything to finish loading: ::
 .. raw:: html
 
     <video width="700px" nocontrols="true" autoplay="true" loop="true">
-        <source src="/_static/videos/mobile_base_arm1.mp4" type="video/mp4">
+        <source src="../../../_static/videos/mobile_base_arm1.mp4" type="video/mp4">
         Planning for differential-drive base and arm
     </video>
 
 .. raw:: html
 
     <video width="700px" nocontrols="true" autoplay="true" loop="true">
-        <source src="/_static/videos/mobile_base_arm2.mp4" type="video/mp4">
+        <source src="../../../_static/videos/mobile_base_arm2.mp4" type="video/mp4">
         Planning after adding a collision object to planning scene
     </video>
 

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -45,7 +45,7 @@ Expected Output
 .. raw:: html
 
     <video width="700px" controls="true" autoplay="true" loop="true">
-        <source src="/_static/videos/Servo_Teleop_Demo.webm" type="video/webm">
+        <source src="../../../_static/videos/Servo_Teleop_Demo.webm" type="video/webm">
         Teleoperation demo with controller
     </video>
 
@@ -66,7 +66,7 @@ Expected Output
 .. raw:: html
 
     <video width="700px" controls="true" autoplay="true" loop="true">
-        <source src="/_static/videos/C++_Interface_Demo.webm" type="video/webm">
+        <source src="../../../_static/videos/C++_Interface_Demo.webm" type="video/webm">
         Joint and Cartesian jogging with collision prevention
     </video>
 

--- a/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -150,7 +150,7 @@ You can use the **Joints** tab to move single joints and the redundant joints of
 .. raw:: html
 
     <video width="700px" controls="true" autoplay="true" loop="true">
-        <source src="/_static/videos/rviz_joints_nullspace.webm" type="video/webm">
+        <source src="../../../_static/videos/rviz_joints_nullspace.webm" type="video/webm">
         The joints moving while the end effector stays still
     </video>
 


### PR DESCRIPTION
### Description

Due to the way multiversion deployment works, we have to use relative paths for videos with the raw html feature.  An example of a broken video is in here:

https://moveit.picknik.ai/main/doc/examples/realtime_servo/realtime_servo_tutorial.html#id1

There are probably more clever ways of doing this but I was not able to figure any of them out.