### PR TITLE
Restore Google Analytics

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -105,6 +105,8 @@ html_theme_options = {
     "collapse_navigation": False,
     "sticky_navigation": True,
     "navigation_depth": -1,
+    # This is the Google Analytics account used by moveit.ros.org, not picknik.ai
+    "analytics_id": 'UA-108532843-1',
 }
 
 html_context = {

--- a/conf.py
+++ b/conf.py
@@ -106,7 +106,7 @@ html_theme_options = {
     "sticky_navigation": True,
     "navigation_depth": -1,
     # This is the Google Analytics account used by moveit.ros.org, not picknik.ai
-    "analytics_id": 'UA-108532843-1',
+    "analytics_id": "UA-108532843-1",
 }
 
 html_context = {


### PR DESCRIPTION
ROS 1 tutorials were connected to the moveit.ros.org Google Analytics account [here](https://github.com/ros-planning/moveit2_tutorials/pull/208/files#diff-796eab59177eac7e3a920bc2c60dab7dc133e977ebcaab971c80c5147d3a3a18L80)

This restores that, though its not using the fancy tag manager approach but just the built in sphynix-rtd-theme approach.

This should be cherry-picked to foxy and galactic. 