### PR TITLE
Fix Examples Links

### DIFF
--- a/doc/examples/bullet_collision_checker/bullet_collision_checker.rst
+++ b/doc/examples/bullet_collision_checker/bullet_collision_checker.rst
@@ -55,10 +55,10 @@ Pressing ``Next`` one more time finishes the tutorial.
 
 Relevant Code
 -------------
-The entire code can be seen :codedir:`here <bullet_collision_checker>` in the moveit_tutorials GitHub project. A lot of information necessary for understanding how this demo works is left out to keep this tutorial focused on Bullet. Please see :doc:`Visualizing Collisions </doc/examples/visualizing_collisions/visualizing_collisions_tutorial>` for code explanation regarding the visualizing of the collisions.
+The entire code can be seen :codedir:`here <examples/bullet_collision_checker>` in the moveit_tutorials GitHub project. A lot of information necessary for understanding how this demo works is left out to keep this tutorial focused on Bullet. Please see :doc:`Visualizing Collisions </doc/examples/visualizing_collisions/visualizing_collisions_tutorial>` for code explanation regarding the visualizing of the collisions.
 
 .. tutorial-formatter:: ./src/bullet_collision_checker_tutorial.cpp
 
 Launch file
 -----------
-The entire launch file is  :codedir:`here <bullet_collision_checker>` on GitHub. All the code in this tutorial can be compiled and run from the ``moveit_tutorials`` package.
+The entire launch file is  :codedir:`here <examples/bullet_collision_checker>` on GitHub. All the code in this tutorial can be compiled and run from the ``moveit_tutorials`` package.

--- a/doc/examples/chomp_planner/chomp_planner_tutorial.rst
+++ b/doc/examples/chomp_planner/chomp_planner_tutorial.rst
@@ -41,7 +41,7 @@ Running CHOMP with Obstacles in the Scene
 +++++++++++++++++++++++++++++++++++++++++
 To run CHOMP in an environment with obstacles, you can run the sample python script:
 
-  :codedir:`collision_scene_example.py<collision_environments/scripts/collision_scene_example.py>`.
+  :codedir:`collision_scene_example.py<examples/collision_environments/scripts/collision_scene_example.py>`.
 
 This script creates a cluttered scene with four obstacles or a simple scene with one obstacle depending on the argument given to the script. One can also change the position/size of the obstacles to change the scene.
 

--- a/doc/examples/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/examples/controller_configuration/controller_configuration_tutorial.rst
@@ -125,7 +125,7 @@ Example Controller Manager
 
 MoveIt controller managers, somewhat a misnomer, are the interfaces to your custom low level controllers. A better way to think of them are *controller interfaces*. For most use cases, the included :moveit_codedir:`MoveItSimpleControllerManager <moveit_plugins/moveit_simple_controller_manager>` is sufficient if your robot controllers already provide ROS actions for FollowJointTrajectory. If you use *ros_control*, the included :moveit_codedir:`MoveItRosControlInterface <moveit_plugins/moveit_ros_control_interface>` is also ideal.
 
-However, for some applications you might desire a more custom controller manager. An example template for starting your custom controller manager is provided :codedir:`here <controller_configuration/src/moveit_controller_manager_example.cpp>`.
+However, for some applications you might desire a more custom controller manager. An example template for starting your custom controller manager is provided :codedir:`here <examples/controller_configuration/src/moveit_controller_manager_example.cpp>`.
 
 Fake Controller Manager
 -----------------------

--- a/doc/examples/creating_moveit_plugins/plugin_tutorial.rst
+++ b/doc/examples/creating_moveit_plugins/plugin_tutorial.rst
@@ -10,7 +10,7 @@ Creating MoveIt Plugins
 
 Motion Planner Plugin
 ----------------------
-In this section, we will show how to add a new motion planner to MoveIt as a plugin. The base class in MoveIt is ``planning_interface`` from  which any new planner plugin should inherit. For demonstration purposes, a linear interpolation planner (lerp) which plans the motion between two states in joint space is created. This planner could be used as a start point for adding any new planner as it contains the necessary basics. The final source files designed in this tutorial are available :codedir:`here <creating_moveit_plugins/lerp_motion_planner/src>`. The following graph shows a brief overall view of the relation between classes for adding a new planner in MoveIt.
+In this section, we will show how to add a new motion planner to MoveIt as a plugin. The base class in MoveIt is ``planning_interface`` from  which any new planner plugin should inherit. For demonstration purposes, a linear interpolation planner (lerp) which plans the motion between two states in joint space is created. This planner could be used as a start point for adding any new planner as it contains the necessary basics. The final source files designed in this tutorial are available :codedir:`here <examples/creating_moveit_plugins/lerp_motion_planner/src>`. The following graph shows a brief overall view of the relation between classes for adding a new planner in MoveIt.
 
 .. image:: lerp_motion_planner/lerp_planner.png
 
@@ -96,7 +96,7 @@ Example Controller Manager Plugin
 
 MoveIt controller managers, somewhat a misnomer, are the interfaces to your custom low level controllers. A better way to think of them are *controller interfaces*. For most use cases, the included :moveit_codedir:`MoveItSimpleControllerManager <moveit_plugins/moveit_simple_controller_manager>` is sufficient if your robot controllers already provide ROS actions for FollowJointTrajectory. If you use *ros_control*, the included :moveit_codedir:`MoveItRosControlInterface <moveit_plugins/moveit_ros_control_interface>` is also ideal.
 
-However, for some applications you might desire a more custom controller manager. An example template for starting your custom controller manager is provided :codedir:`here <controller_configuration/src/moveit_controller_manager_example.cpp>`.
+However, for some applications you might desire a more custom controller manager. An example template for starting your custom controller manager is provided :codedir:`here <examples/controller_configuration/src/moveit_controller_manager_example.cpp>`.
 
 
 Example Constraint Sampler Plugin

--- a/doc/examples/motion_planning_api/motion_planning_api_tutorial.rst
+++ b/doc/examples/motion_planning_api/motion_planning_api_tutorial.rst
@@ -52,10 +52,10 @@ In RViz, we should be able to see four trajectories being replayed eventually:
 
 The Entire Code
 ---------------
-The entire code can be seen :codedir:`here in the moveit_tutorials GitHub project<motion_planning_api>`.
+The entire code can be seen :codedir:`here in the moveit_tutorials GitHub project<examples/motion_planning_api>`.
 
 .. tutorial-formatter:: ./src/motion_planning_api_tutorial.cpp
 
 The Launch File
 ---------------
-The entire launch file is :codedir:`here <motion_planning_api/launch/motion_planning_api_tutorial.launch.py>` on GitHub. All the code in this tutorial can be compiled and run from the moveit_tutorials package.
+The entire launch file is :codedir:`here <examples/motion_planning_api/launch/motion_planning_api_tutorial.launch.py>` on GitHub. All the code in this tutorial can be compiled and run from the moveit_tutorials package.

--- a/doc/examples/motion_planning_pipeline/motion_planning_pipeline_tutorial.rst
+++ b/doc/examples/motion_planning_pipeline/motion_planning_pipeline_tutorial.rst
@@ -42,10 +42,10 @@ In RViz, we should be able to see three trajectories being replayed eventually:
 
 The Entire Code
 ---------------
-The entire code can be seen :codedir:`here in the MoveIt GitHub project<motion_planning_pipeline>`.
+The entire code can be seen :codedir:`here in the MoveIt GitHub project<examples/motion_planning_pipeline>`.
 
 .. tutorial-formatter:: ./src/motion_planning_pipeline_tutorial.cpp
 
 The Launch File
 ---------------
-The entire launch file is :codedir:`here <motion_planning_pipeline/launch/motion_planning_pipeline_tutorial.launch>` on GitHub. All the code in this tutorial can be compiled and run from the moveit_tutorials package that you have as part of your MoveIt setup.
+The entire launch file is :codedir:`here <examples/motion_planning_pipeline/launch/motion_planning_pipeline_tutorial.launch>` on GitHub. All the code in this tutorial can be compiled and run from the moveit_tutorials package that you have as part of your MoveIt setup.

--- a/doc/examples/move_group_interface/move_group_interface_tutorial.rst
+++ b/doc/examples/move_group_interface/move_group_interface_tutorial.rst
@@ -45,13 +45,13 @@ See the `YouTube video <https://youtu.be/_5siHkFQPBQ>`_ at the top of this tutor
 
 The Entire Code
 ---------------
-The entire code can be seen :codedir:`here in the MoveIt GitHub project<move_group_interface/src/move_group_interface_tutorial.cpp>`. Next, we step through the code piece by piece to explain its functionality.
+The entire code can be seen :codedir:`here in the MoveIt GitHub project<examples/move_group_interface/src/move_group_interface_tutorial.cpp>`. Next, we step through the code piece by piece to explain its functionality.
 
 .. tutorial-formatter:: ./src/move_group_interface_tutorial.cpp
 
 The Launch File
 ---------------
-The entire launch file is :codedir:`here<move_group_interface/launch/move_group_interface_tutorial.launch.py>` on GitHub. All the code in this tutorial can be run from the **moveit2_tutorials** package that you have as part of your MoveIt setup.
+The entire launch file is :codedir:`here<examples/move_group_interface/launch/move_group_interface_tutorial.launch.py>` on GitHub. All the code in this tutorial can be run from the **moveit2_tutorials** package that you have as part of your MoveIt setup.
 
 
 A Note on Setting Tolerances

--- a/doc/examples/move_group_python_interface/move_group_python_interface_tutorial.rst
+++ b/doc/examples/move_group_python_interface/move_group_python_interface_tutorial.rst
@@ -49,12 +49,12 @@ Press *<enter>* in the shell terminal where you ran the ``rosrun`` command in be
 
 The Entire Code
 ---------------
-Note: the entire code can be seen :codedir:`here in the tutorials GitHub repository<move_group_python_interface/scripts/move_group_python_interface_tutorial.py>`.
+Note: the entire code can be seen :codedir:`here in the tutorials GitHub repository<examples/move_group_python_interface/scripts/move_group_python_interface_tutorial.py>`.
 
 .. tutorial-formatter:: ./scripts/move_group_python_interface_tutorial.py
 
 The Launch File
 ---------------
-The entire launch file is :codedir:`here<move_group_python_interface/launch/move_group_python_interface_tutorial.launch>`
+The entire launch file is :codedir:`here<examples/move_group_python_interface/launch/move_group_python_interface_tutorial.launch>`
 on GitHub. All the code in this tutorial can be run from the
 ``moveit_tutorials`` package that you have as part of your MoveIt setup.

--- a/doc/examples/moveit_cpp/moveitcpp_tutorial.rst
+++ b/doc/examples/moveit_cpp/moveitcpp_tutorial.rst
@@ -23,10 +23,10 @@ After a short moment, the RViz window should appear and look similar to the one 
 
 The Entire Code
 ---------------
-The entire code can be seen :codedir:`here in the MoveIt GitHub project<moveit_cpp/src/moveit_cpp_tutorial.cpp >`. Next we step through the code piece by piece to explain its functionality.
+The entire code can be seen :codedir:`here in the MoveIt GitHub project<examples/moveit_cpp/src/moveit_cpp_tutorial.cpp >`. Next we step through the code piece by piece to explain its functionality.
 
 .. tutorial-formatter:: ./src/moveit_cpp_tutorial.cpp
 
 The Launch File
 ---------------
-The entire launch file is :codedir:`here<moveit_cpp/launch/moveit_cpp_tutorial.launch.py>` on GitHub. All the code in this tutorial can be run from the **moveit2_tutorials** package that you have as part of your MoveIt setup.
+The entire launch file is :codedir:`here<examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py>` on GitHub. All the code in this tutorial can be run from the **moveit2_tutorials** package that you have as part of your MoveIt setup.

--- a/doc/examples/perception_pipeline/perception_pipeline_tutorial.rst
+++ b/doc/examples/perception_pipeline/perception_pipeline_tutorial.rst
@@ -179,7 +179,7 @@ You can follow its status in the `issue tracker <https://github.com/ros-planning
 
 Relevant Code
 +++++++++++++
-The entire code can be seen :codedir:`here<perception_pipeline>` in the moveit_tutorials GitHub project.
+The entire code can be seen :codedir:`here<examples/perception_pipeline>` in the moveit_tutorials GitHub project.
 
 The details regarding the implementation of each of the perception pipeline function have been omitted in this tutorial as they are well documented `here <http://wiki.ros.org/pcl/Tutorials>`_.
 

--- a/doc/examples/pick_place/pick_place_tutorial.rst
+++ b/doc/examples/pick_place/pick_place_tutorial.rst
@@ -46,7 +46,7 @@ The relevant fields of the message are:-
 
 The Entire Code
 ---------------
-The entire code can be seen :codedir:`here <pick_place>` in the moveit_tutorials GitHub project.
+The entire code can be seen :codedir:`here <examples/pick_place>` in the moveit_tutorials GitHub project.
 
 .. |br| raw:: html
 

--- a/doc/examples/planning_scene/planning_scene_tutorial.rst
+++ b/doc/examples/planning_scene/planning_scene_tutorial.rst
@@ -11,13 +11,13 @@ If you haven't already done so, make sure you've completed the steps in :doc:`Ge
 
 The entire code
 ---------------
-The entire code can be seen :codedir:`here in the MoveIt GitHub project<planning_scene>`.
+The entire code can be seen :codedir:`here in the MoveIt GitHub project<examples/planning_scene>`.
 
 .. tutorial-formatter:: ./src/planning_scene_tutorial.cpp
 
 The launch file
 ---------------
-The entire launch file is :codedir:`here <planning_scene/launch/planning_scene_tutorial.launch.py>` on GitHub. All the code in this tutorial can be compiled and run from the moveit_tutorials package.
+The entire launch file is :codedir:`here <examples/planning_scene/launch/planning_scene_tutorial.launch.py>` on GitHub. All the code in this tutorial can be compiled and run from the moveit_tutorials package.
 
 Running the code
 ----------------

--- a/doc/examples/planning_scene_ros_api/planning_scene_ros_api_tutorial.rst
+++ b/doc/examples/planning_scene_ros_api/planning_scene_ros_api_tutorial.rst
@@ -33,7 +33,7 @@ In RViz, you should be able to see the following:
 
 The entire code
 ---------------
-The entire code can be seen :codedir:`here in the MoveIt GitHub project<planning_scene_ros_api>`.
+The entire code can be seen :codedir:`here in the MoveIt GitHub project<examples/planning_scene_ros_api>`.
 
 .. tutorial-formatter:: ./src/planning_scene_ros_api_tutorial.cpp
 

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -72,7 +72,7 @@ Expected Output
 
 Entire Code
 -----------
-The entire code is available :codedir:`here<realtime_servo/src/servo_cpp_interface_demo.cpp>`
+The entire code is available :codedir:`here<examples/realtime_servo/src/servo_cpp_interface_demo.cpp>`
 
 .. tutorial-formatter:: ./src/servo_cpp_interface_demo.cpp
 

--- a/doc/examples/robot_model_and_robot_state/robot_model_and_robot_state_tutorial.rst
+++ b/doc/examples/robot_model_and_robot_state/robot_model_and_robot_state_tutorial.rst
@@ -78,7 +78,7 @@ The expected output will be in the following form. The numbers will not match si
 
 The Entire Code
 ---------------
-The entire code can be seen :codedir:`here in the MoveIt GitHub project<robot_model_and_robot_state/src/robot_model_and_robot_state_tutorial.cpp>`.
+The entire code can be seen :codedir:`here in the MoveIt GitHub project<examples/robot_model_and_robot_state/src/robot_model_and_robot_state_tutorial.cpp>`.
 
 .. tutorial-formatter:: ./src/robot_model_and_robot_state_tutorial.cpp
 

--- a/doc/examples/stomp_planner/stomp_planner_tutorial.rst
+++ b/doc/examples/stomp_planner/stomp_planner_tutorial.rst
@@ -90,7 +90,7 @@ Running STOMP with Obstacles in the Scene
 +++++++++++++++++++++++++++++++++++++++++
 To run STOMP in an environment with obstacles, you can run the sample python script:
 
-  :codedir:`collision_scene_example.py<collision_environments/scripts/collision_scene_example.py>`.
+  :codedir:`collision_scene_example.py<examples/collision_environments/scripts/collision_scene_example.py>`.
 
 This scripts creates a cluttered scene with four ostacles or a simple scene with one obstacle depending on the argument given to the script. One can also change the position/size of the obstacles to change the scene.
 

--- a/doc/examples/subframes/subframes_tutorial.rst
+++ b/doc/examples/subframes/subframes_tutorial.rst
@@ -39,7 +39,7 @@ In this terminal you should be able to enter numbers from 1-12 to send commands,
 
 The Code
 ---------------
-The code for this example can be seen :codedir:`here <subframes>` in the moveit_tutorials GitHub project and is explained in detail below.
+The code for this example can be seen :codedir:`here <examples/subframes>` in the moveit_tutorials GitHub project and is explained in detail below.
 
 The code spawns a box and a cylinder in the planning scene, attaches the cylinder to the
 robot, and then lets you send motion commands via the command line. It also defines two

--- a/doc/examples/tests/tests_tutorial.rst
+++ b/doc/examples/tests/tests_tutorial.rst
@@ -42,7 +42,7 @@ Unit Tests
 Writing Unit Tests
 ~~~~~~~~~~~~~~~~~~
 
-The entire test file, with includes, can be seen :codedir:`here <tests>` in the moveit_tutorials GitHub project.
+The entire test file, with includes, can be seen :codedir:`here <examples/tests>` in the moveit_tutorials GitHub project.
 
 MoveIt uses Google Test as a testing framework.
 

--- a/doc/examples/visualizing_collisions/visualizing_collisions_tutorial.rst
+++ b/doc/examples/visualizing_collisions/visualizing_collisions_tutorial.rst
@@ -40,10 +40,10 @@ Move the right arm so it is in contact with the yellow cube (you may also move t
 
 Relevant Code
 -------------
-The entire code can be seen :codedir:`here <visualizing_collisions>` in the moveit_tutorials GitHub project. Libraries used can be found :codedir:`here <interactivity>`. A lot of information necessary for understanding how this demo works is left out to keep this tutorial focused on collision contacts. To understand this demo fully, it is highly recommended that you read through the source code.
+The entire code can be seen :codedir:`here <examples/visualizing_collisions>` in the moveit_tutorials GitHub project. Libraries used can be found :codedir:`here <examples/interactivity>`. A lot of information necessary for understanding how this demo works is left out to keep this tutorial focused on collision contacts. To understand this demo fully, it is highly recommended that you read through the source code.
 
 .. tutorial-formatter:: ./src/visualizing_collisions_tutorial.cpp
 
 Launch file
 -----------
-The entire launch file is  :codedir:`here <visualizing_collisions>` on GitHub. All the code in this tutorial can be compiled and run from the moveit_tutorials package.
+The entire launch file is  :codedir:`here <examples/visualizing_collisions>` on GitHub. All the code in this tutorial can be compiled and run from the moveit_tutorials package.

--- a/doc/examples/visualizing_collisions/visualizing_collisions_tutorial.rst
+++ b/doc/examples/visualizing_collisions/visualizing_collisions_tutorial.rst
@@ -29,7 +29,7 @@ Classes
 -------
 The code for this tutorial is mainly in the :code:`InteractiveRobot` class which we will walk through below. The :code:`InteractiveRobot` class maintains a :code:`RobotModel`, a :code:`RobotState`, and information about 'the world' (in this case "the world" is a single yellow cube).
 
-The :code:`InteractiveRobot` class uses the :code:`IMarker` class which maintains an interactive marker. This tutorial does not cover the implementation of the IMarker class (:codedir:`imarker.cpp <interactivity/src/imarker.cpp>`), but most of the code is copied from the `basic_controls <http://wiki.ros.org/rviz/Tutorials/Interactive%20Markers:%20Getting%20Started#basic_controls>`_ tutorial and you can read more there about interactive markers if you are interested.
+The :code:`InteractiveRobot` class uses the :code:`IMarker` class which maintains an interactive marker. This tutorial does not cover the implementation of the IMarker class (:codedir:`imarker.cpp <examples/interactivity/src/imarker.cpp>`), but most of the code is copied from the `basic_controls <http://wiki.ros.org/rviz/Tutorials/Interactive%20Markers:%20Getting%20Started#basic_controls>`_ tutorial and you can read more there about interactive markers if you are interested.
 
 Interacting
 -----------


### PR DESCRIPTION
The links in the examples tutorials didn't contain "examples/" prefix. Fixed'em.