### PR TITLE
Improve wording of different versions, add CSS to warning box

### DIFF
--- a/_templates/page.html
+++ b/_templates/page.html
@@ -1,40 +1,30 @@
 {% extends "!page.html" %}
-{% block header %}
-<div class="pageheader">
-  <div align="center">
-    <br/>
-    <table id="topnav-table">
-      <tr>
-        <td valign="middle">
-          ROS Resources:
-            <a href="http://discourse.ros.org/">Discussion Forum</a>
-            |
-            <a href="http://status.ros.org/">Service Status</a>
-            |
-            <a href="http://answers.ros.org/">Q&A answers.ros.org</a>
 
-        </td>
-      </tr>
-    </table>
-  </div>
-</div>
-{% endblock %}
 {% block body %}
 {% if current_version and latest_version and current_version != latest_version %}
-<p>
-  <strong>
-    {% if current_version.name|string() in eol_versions %}
-    You're reading the documentation for a version of ROS 2 that has reached its EOL (end-of-life), and is no longer officially supported.
-    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
-    {% elif current_version.is_released %}
-    You're reading the documentation for an older, but still supported, version of ROS 2.
-    For information on the latest version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
-    {% else %}
-    You're reading the documentation for a development version.
-    For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
-    {% endif %}
-  </strong>
-</p>
+
+<div class="admonition note">
+  <p class="first admonition-title">Documentation Version</p>
+  <p class="last">
+      {% if current_version.name|string() in eol_versions %}
+      You're reading the documentation for a version of MoveIt 2 that has reached its EOL (end-of-life),
+      and is no longer officially supported.
+      If you want up-to-date information, please have a look at
+      <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+
+      {% elif current_version.is_released %}
+      You're reading the documentation for an older, but still supported, version of MoveIt 2.
+      For information on the recommended stable version, please have a look at
+      <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+
+      {% else %}
+      You're reading the documentation for the non-stable development version of MoveIt 2.
+      For the stable, released version, please have a look at
+      <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name | title }}</a>.
+      {% endif %}
+  </p>
+</div>
+
 {% endif %}
 {{ super() }}
 {% endblock %}%

--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -7,25 +7,25 @@
   </span>
   <div class="rst-other-versions">
     <dl>
-      <dt>Releases</dt>
+      <dt>MoveIt 2 - Rolling (Development)</dt>
+      {%- for item in versions.in_development|sort(reverse=True) %}
+      <dd><a href="{{ item.url }}">{{ item.name|title }} (latest)</a></dd>
+      {%- endfor %}
+    </dl>
+    <dl>
+      <dt>MoveIt 2 - Stable</dt>
       {%- for item in versions.releases|sort(reverse=True) %}
         {%- if item.name == latest_version.name %}
-        <dd><a href="{{ item.url }}">{{ item.name|title }} (latest)</a></dd>
+        <dd><a href="{{ item.url }}">{{ item.name|title }} (recommended)</a></dd>
         {%- elif item.name in eol_versions %}
         <dd><a href="{{ item.url }}">{{ item.name|title }} (EOL)</a></dd>
         {% else %}
         <dd><a href="{{ item.url }}">{{ item.name|title }}</a></dd>
         {%- endif %}
       {%- endfor %}
-    </dl>
+   </dl>
     <dl>
-      <dt>In Development</dt>
-      {%- for item in versions.in_development|sort(reverse=True) %}
-      <dd><a href="{{ item.url }}">{{ item.name|title }}</a></dd>
-      {%- endfor %}
-    </dl>
-    <dl>
-      <dt>ROS 1</dt>
+      <dt>MoveIt 1 - Stable</dt>
       <dd><a href="https://ros-planning.github.io/moveit_tutorials/">Noetic</a></dd>
       <dd><a href="http://docs.ros.org/en/melodic/api/moveit_tutorials/html/index.html">Melodic</a></dd>
     </dl>


### PR DESCRIPTION
I think we should call our ``main`` branch "latest" and our ``foxy`` branch "stable / recommended", similar to how [this ReadTheDocs example website](https://sphinx-rtd-theme.readthedocs.io/en/stable/) does it:
![image](https://user-images.githubusercontent.com/561060/149595977-b82723a0-0f5f-4890-81e2-6e25d71f1b77.png)

As such I have made ours look like this:
![image](https://user-images.githubusercontent.com/561060/149596038-5094d0c0-c262-48b8-89ed-39d84f7bf0f1.png)

I've also turned back on the old CSS that makes alert boxes look nicer:
![image](https://user-images.githubusercontent.com/561060/149596119-fe351644-b0cf-428f-b1f9-70139109a86b.png)
