### PR TITLE
Use sphinx 4.3.2 to fix sphinx-builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip
 docutils==0.16
-sphinx
+sphinx==4.3.2
 sphinx-tabs
 sphinx-multiversion
 sphinx-rtd-theme


### PR DESCRIPTION
Sphinx 4.4.0 (released yesterday) seems broken and causing sphinx-build to fail in CI and local builds. This forces pip to install 4.3.2 instead to fix the builds temporarily.