### PR TITLE
Reorder Top Level Navigation

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -25,11 +25,11 @@ Table Of Contents
    :maxdepth: 2
 
    doc/tutorials/tutorials
-   doc/how_to_guides/how_to_guides
-   doc/concepts/concepts
-   doc/how_to_contribute/how_to_contribute
    doc/examples/examples
+   doc/concepts/concepts
+   doc/how_to_guides/how_to_guides
    doc/api/api
+   doc/how_to_contribute/how_to_contribute
 
 Attribution
 -----------


### PR DESCRIPTION
With the new tutorials layout, it appears at first glance we have far less content now. To reduce this, I think we should move "Examples" up in the nav right under Tutorials, since that is where the bulk of the content still lives. I think we should order based on relevant to a beginner user:

- Tutorials
- Examples (where all the old tutorials now live)
- Concepts
- How-To-Guides (there is almost nothing here currently)
- API Documentation
- Contributing (this is important to PickNik developers maybe, but not the most important thing for new users)