### PR TITLE
Add missing rosdep command

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -18,6 +18,7 @@ Install `rosdep <http://wiki.ros.org/rosdep>`_ to install system dependencies : 
 
 Once you have ROS 2 installed, make sure you have the most up to date packages: ::
 
+  sudo rosdep init
   rosdep update
   sudo apt update
   sudo apt dist-upgrade


### PR DESCRIPTION
### Description

`sudo rosdep init` must be called before running `rosdep update`. The instructions to install ROS via Debian packages never instructs the user to do this so we must add this command here.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
