### PR TITLE
Changed rolling to galactic in tutorials

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -361,8 +361,7 @@ class RedirectFrom(Directive):
                     "title": os.path.basename(redirect_url),
                     "metatags": redirect_html_fragment.format(
                         base_url=app.config.html_baseurl,
-                        url=app.builder.get_relative_uri(
-                            redirect_url, canonical_url),
+                        url=app.builder.get_relative_uri(redirect_url, canonical_url),
                     ),
                 }
                 yield (redirect_url, context, cls.template_name)

--- a/conf.py
+++ b/conf.py
@@ -82,7 +82,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    "ros2": ("https://docs.ros.org/en/rolling/", None),
+    "ros2": ("https://docs.ros.org/en/galactic/", None),
     "catkin_pkg": ("http://docs.ros.org/en/independent/api/catkin_pkg/html", None),
     "jenkins_tools": (
         "http://docs.ros.org/en/independent/api/jenkins_tools/html",
@@ -141,9 +141,9 @@ distro_full_names = {
 
 # These default values will be overridden when building multiversion
 macros = {
-    "DISTRO": "rolling",
-    "DISTRO_TITLE": "Rolling",
-    "DISTRO_TITLE_FULL": "Rolling Ridley",
+    "DISTRO": "galactic",
+    "DISTRO_TITLE": "Galactic",
+    "DISTRO_TITLE_FULL": "Galactic Geochelone",
     "REPOS_FILE_BRANCH": "main",
 }
 
@@ -170,12 +170,12 @@ html_sourcelink_suffix = ""
 # Output file base name for HTML help builder.
 htmlhelp_basename = "MoveItDocumentation"
 
-html_baseurl = "https://moveit.picknik.ai/rolling/"
+html_baseurl = "https://moveit.picknik.ai/galactic/"
 
 # Add any paths that contain custom themes here, relative to this directory.
 
 # Links
-ros_distro = "rolling"
+ros_distro = "galactic"
 lang = "en"
 ros1_distro = "noetic"
 extlinks = {
@@ -361,7 +361,8 @@ class RedirectFrom(Directive):
                     "title": os.path.basename(redirect_url),
                     "metatags": redirect_html_fragment.format(
                         base_url=app.config.html_baseurl,
-                        url=app.builder.get_relative_uri(redirect_url, canonical_url),
+                        url=app.builder.get_relative_uri(
+                            redirect_url, canonical_url),
                     ),
                 }
                 yield (redirect_url, context, cls.template_name)

--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -8,7 +8,7 @@ Install ROS 2 and Colcon
 :ros_documentation:`Install ROS 2 {DISTRO_TITLE}<Installation.html>`.
 It is easy to miss steps when going through the ROS 2 installation tutorial. If you run into errors in the next few steps, a good place to start is to go back and make sure you have installed ROS 2 correctly.  One that users commonly forget is to source the ROS 2 install itself.  ::
 
-  source /opt/ros/rolling/setup.bash
+  source /opt/ros/galactic/setup.bash
 
 .. note:: Unlike ROS 1 setup scripts, in ROS 2 the setup scripts do not attempt to switch what version of ROS you are using.  This means that if you have previously sourced a different version of ROS, including from within your ``.bashrc`` file, you will run into errors during the building step.  To fix this change what is sourced in your ``.bashrc`` and start a new terminal.
 

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -24,8 +24,8 @@ grep -rl 'https:\/\/github.com\/ros-planning\/moveit2_tutorials\/blob\/main\/' .
  xargs sed -i "s|https://github.com/ros-planning/moveit2_tutorials/blob/main/|file://$PWD|g"
 
 # Replace internal links with local file paths
-grep -rl 'https:\/\/moveit.picknik.ai\/rolling\/' ./build/ | \
- xargs sed -i "s|https://moveit.picknik.ai/rolling/|file://$PWD|g"
+grep -rl 'https:\/\/moveit.picknik.ai\/galactic\/' ./build/ | \
+ xargs sed -i "s|https://moveit.picknik.ai/galactic/|file://$PWD|g"
 
 # Run HTML tests on generated build output to check for 404 errors, etc
 htmlproofer ./build \


### PR DESCRIPTION
### Description

Corrected the ROS_DISTRO in conf.py file in the galactic branch from rolling to galactic. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
