### PR TITLE
Update yaml names

### DIFF
--- a/doc/examples/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/examples/controller_configuration/controller_configuration_tutorial.rst
@@ -2,7 +2,7 @@ Low Level Controllers
 =====================
 MoveIt typically publishes manipulator motion commands to a `JointTrajectoryController <https://github.com/ros-controls/ros2_controllers/tree/master/joint_trajectory_controller>`_. This tutorial assumes MoveGroup is being used to control the robot rather than MoveItCpp or MoveIt Servo. A minimal setup is as follows:
 
-#. A YAML config file. As best practice, we suggest naming this :code:`moveit_controllers.yaml`. It tells MoveIt which controllers are available, which joints are associated with each, and the MoveIt controller interface type (:code:`FollowJointTrajectory` or :code:`GripperCommand`). `Example controller config file <https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/config/panda_controllers.yaml>`_.
+#. A YAML config file. As best practice, we suggest naming this :code:`moveit_controllers.yaml`. It tells MoveIt which controllers are available, which joints are associated with each, and the MoveIt controller interface type (:code:`FollowJointTrajectory` or :code:`GripperCommand`). `Example controller config file <https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/config/panda_moveit_controllers.yaml>`_.
 
 #. A launch file. This launch file must load the :code:`moveit_controllers` yaml file and specify the :code:`moveit_simple_controller_manager/MoveItSimpleControllerManager`. After these yaml files are loaded, they are passed as parameters to the Move Group node. `Example Move Group launch file <https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/launch/demo.launch.py>`_.
 

--- a/doc/examples/move_group_interface/launch/move_group.launch.py
+++ b/doc/examples/move_group_interface/launch/move_group.launch.py
@@ -62,7 +62,7 @@ def generate_launch_description():
     ros2_controllers_path = os.path.join(
         get_package_share_directory("moveit_resources_panda_moveit_config"),
         "config",
-        "panda_ros_controllers.yaml",
+        "panda_ros2_controllers.yaml",
     )
     ros2_control_node = Node(
         package="controller_manager",

--- a/doc/examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
+++ b/doc/examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
     ros2_controllers_path = os.path.join(
         get_package_share_directory("moveit_resources_panda_moveit_config"),
         "config",
-        "panda_ros_controllers.yaml",
+        "panda_ros2_controllers.yaml",
     )
     ros2_control_node = Node(
         package="controller_manager",

--- a/doc/examples/persistent_scenes_and_states/move_group.launch.py
+++ b/doc/examples/persistent_scenes_and_states/move_group.launch.py
@@ -89,7 +89,7 @@ def generate_launch_description():
     ros2_controllers_path = os.path.join(
         get_package_share_directory("moveit_resources_panda_moveit_config"),
         "config",
-        "panda_ros_controllers.yaml",
+        "panda_ros2_controllers.yaml",
     )
     ros2_control_node = Node(
         package="controller_manager",

--- a/doc/examples/realtime_servo/launch/servo_cpp_interface_demo.launch.py
+++ b/doc/examples/realtime_servo/launch/servo_cpp_interface_demo.launch.py
@@ -79,7 +79,7 @@ def generate_launch_description():
             os.path.join(
                 get_package_share_directory("moveit_resources_panda_moveit_config"),
                 "config",
-                "panda_ros_controllers.yaml",
+                "panda_ros2_controllers.yaml",
             ),
         ],
         output={

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -76,7 +76,7 @@ def generate_launch_description():
 
     # Trajectory Execution Functionality
     moveit_simple_controllers_yaml = load_yaml(
-        "moveit_resources_panda_moveit_config", "config/panda_controllers.yaml"
+        "moveit_resources_panda_moveit_config", "config/panda_moveit_controllers.yaml"
     )
     moveit_controllers = {
         "moveit_simple_controller_manager": moveit_simple_controllers_yaml,
@@ -169,7 +169,7 @@ def generate_launch_description():
     ros2_controllers_path = os.path.join(
         get_package_share_directory("moveit_resources_panda_moveit_config"),
         "config",
-        "panda_ros_controllers.yaml",
+        "panda_ros2_controllers.yaml",
     )
     ros2_control_node = Node(
         package="controller_manager",


### PR DESCRIPTION
This fixes some issues caused by a large config change PR in moveit_resources (https://github.com/ros-planning/moveit_resources/pull/98). Prob should be tested by somebody else before merging.

Should be merged with https://github.com/ros-planning/moveit_resources/pull/117 to keep the config filenames synced.
