### PR TITLE
Revert #198 - Fix future deprecation warning

### DIFF
--- a/doc/examples/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
+++ b/doc/examples/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv)
   auto request = std::make_shared<moveit_msgs::srv::ApplyPlanningScene::Request>();
   request->scene = planning_scene;
   std::shared_future<std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene_Response>> response_future;
-  response_future = planning_scene_diff_client->async_send_request(request);
+  response_future = planning_scene_diff_client->async_send_request(request).future.share();
 
   // wait for the service to respond
   std::chrono::seconds wait_time(1);


### PR DESCRIPTION
### Description

When I build the tutorials on ros2 rolling I got the following warning:
```
warning: ‘rclcpp::Client<ServiceT>::FutureAndRequestId::operator rclcpp::Client<ServiceT>::SharedFuture() [with ServiceT = moveit_msgs::srv::ApplyPlanningScene; rclcpp::Client<ServiceT>::SharedFuture = std::shared_future<std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene_Response_<std::allocator<void> > > >; typename ServiceT::Response::SharedPtr = std::shared_ptr<moveit_msgs::srv::ApplyPlanningScene_Response_<std::allocator<void> > >]’ is deprecated: FutureAndRequestId: use .future.share() instead of an implicit conversion [-Wdeprecated-declarations]
```
This PR fixes the warning and reverts the changes introduced by #198. It does not seem deprecated in foxy or galactic so I am not sure if this commit should be backported. @tylerjw What is your opinion on this?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
