### PR TITLE
Remove unnecessary line as already included in panda_controllers.yaml

### DIFF
--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -80,7 +80,6 @@ def generate_launch_description():
     )
     moveit_controllers = {
         "moveit_simple_controller_manager": moveit_simple_controllers_yaml,
-        "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
     }
 
     trajectory_execution = {


### PR DESCRIPTION
### Description

The line is already included in `panda_controllers.yaml`
https://github.com/ros-planning/moveit_resources/blob/galactic/panda_moveit_config/config/panda_controllers.yaml#L6

Removing to avoid confusion

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
