### PR TITLE
Update launch file to use output="both"

### DIFF
--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -175,10 +175,7 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[robot_description, ros2_controllers_path],
-        output={
-            "stdout": "screen",
-            "stderr": "screen",
-        },
+        output="both",
     )
 
     # Load controllers


### PR DESCRIPTION
### Description

Fix this error due to a recent ROS2 Rolling change:

`stdoutstderr is not a valid standard output config i.e. "screen", "log" or "both"`
