### PR TITLE
Fix references to depreciated PlanningSceneMonitor constructor

### DIFF
--- a/doc/examples/realtime_servo/src/servo_cpp_interface_demo.cpp
+++ b/doc/examples/realtime_servo/src/servo_cpp_interface_demo.cpp
@@ -107,9 +107,8 @@ int main(int argc, char** argv)
 
   // Create the planning_scene_monitor. We need to pass this to Servo's constructor, and we should set it up first
   // before initializing any collision objects
-  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
   auto planning_scene_monitor = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(
-      node_, "robot_description", tf_buffer, "planning_scene_monitor");
+      node_, "robot_description", "planning_scene_monitor");
 
   // Here we make sure the planning_scene_monitor is updating in real time from the joint states topic
   if (planning_scene_monitor->getPlanningScene())

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -18,7 +18,7 @@ repositories:
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools
-    version: 4.0.0
+    version: 4.1.0
   rviz_visual_tools:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
### Description

Including tf2_ros::Buffer in the PlanningSceneMonitor constructor has been depreciated, fixing leftover references here:
- moveit_visual_tools version 4.1.0 fixed a depreciated constructor, updated the version to be pulled by this package (building with 4.0.0 results in a warning).
- servo demo had a leftover depreciated constructor

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
