### PR TITLE
Use https git URL for cloning srdf repo

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -25,5 +25,5 @@ repositories:
     version: ros2
   srdfdom:
     type: git
-    url: git@github.com:ros-planning/srdfdom.git
+    url: https://github.com/ros-planning/srdfdom.git
     version: ros2


### PR DESCRIPTION
### Description

If git is not setup with ssh the cloning step will fail.

```
vcs import < moveit2_tutorials/moveit2_tutorials.repos
```

I was following this moveit2 tutorial:
https://moveit.picknik.ai/main/doc/tutorials/getting_started/getting_started.html#create-a-colcon-workspace-and-download-tutorials


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
