### PR TITLE
Change source source /opt/ros/rolling/setup.bash to source /opt/ros/h…

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -8,7 +8,7 @@ Install ROS 2 and Colcon
 :ros_documentation:`Install ROS 2 {DISTRO_TITLE}<Installation.html>`.
 It is easy to miss steps when going through the ROS 2 installation tutorial. If you run into errors in the next few steps, a good place to start is to go back and make sure you have installed ROS 2 correctly.  One that users commonly forget is to source the ROS 2 install itself.  ::
 
-  source /opt/ros/rolling/setup.bash
+  source /opt/ros/humble/setup.bash
 
 .. note:: Unlike ROS 1 setup scripts, in ROS 2 the setup scripts do not attempt to switch what version of ROS you are using.  This means that if you have previously sourced a different version of ROS, including from within your ``.bashrc`` file, you will run into errors during the building step.  To fix this change what is sourced in your ``.bashrc`` and start a new terminal.
 

--- a/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
+++ b/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
@@ -197,7 +197,7 @@ Lastly, build your project again to make sure all the code additions are correct
 .. code-block:: bash
 
   cd ~/ws_moveit2
-  source /opt/ros/rolling/setup.bash
+  source /opt/ros/humble/setup.bash
   colcon build --mixin debug
 
 6 Enable visualizations in RViz


### PR DESCRIPTION
The tutorials instructed users to source rolling release of ROS 2, but it should  be sourcing humble version.
