### PR TITLE
Quickstart tutorial: Add an integration test for the expected nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,54 +5,35 @@ project(moveit2_tutorials)
 find_package(moveit_common REQUIRED)
 moveit_package()
 
-find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED system filesystem date_time thread)
-find_package(ament_cmake REQUIRED)
-find_package(control_msgs REQUIRED)
-find_package(moveit_core REQUIRED)
-find_package(moveit_task_constructor_core REQUIRED)
-find_package(moveit_ros_planning REQUIRED)
-find_package(moveit_ros_planning_interface REQUIRED)
-find_package(moveit_ros_perception REQUIRED)
-find_package(moveit_servo REQUIRED)
-find_package(interactive_markers REQUIRED)
-find_package(rviz_visual_tools REQUIRED)
-find_package(moveit_visual_tools REQUIRED)
-find_package(geometric_shapes REQUIRED)
-#find_package(pcl_ros REQUIRED)
-#find_package(pcl_conversions REQUIRED)
-#find_package(rosbag REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
-find_package(pluginlib REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(tf2_eigen REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
-
 set(THIS_PACKAGE_INCLUDE_DIRS
   doc/interactivity/include
 )
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   ament_cmake
-  rclcpp
-  rclcpp_action
-  tf2_geometry_msgs
-  tf2_ros
-  moveit_core
-  rviz_visual_tools
-  moveit_visual_tools
-  moveit_ros_planning_interface
-  interactive_markers
-  tf2_geometry_msgs
-  moveit_ros_planning
-  pluginlib
-  Eigen3
   Boost
   control_msgs
+  Eigen3
+  interactive_markers
+  moveit_core
+  moveit_msgs
+  moveit_ros_planning
+  moveit_ros_planning_interface
   moveit_servo
   moveit_task_constructor_core
+  moveit_visual_tools
+  pluginlib
+  rclcpp
+  rclcpp_action
+  rviz_visual_tools
+  tf2_geometry_msgs
+  tf2_geometry_msgs
+  tf2_ros
 )
+
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
 
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
 

--- a/doc/tutorials/quickstart_in_rviz/CMakeLists.txt
+++ b/doc/tutorials/quickstart_in_rviz/CMakeLists.txt
@@ -1,1 +1,24 @@
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ros_testing REQUIRED)
+  find_package(Boost REQUIRED COMPONENTS filesystem)
+
+  # These don't pass yet, disable them for now
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  set(ament_cmake_flake8_FOUND TRUE)
+  set(ament_cmake_uncrustify_FOUND TRUE)
+
+  # Run all lint tests in package.xml except those listed above
+  ament_lint_auto_find_test_dependencies()
+
+  # Basic "quickstart_in_rviz" bringup test
+  ament_add_gtest_executable(bringup_test
+    test/bringup_test.cpp
+  )
+  ament_target_dependencies(bringup_test ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  add_ros_test(test/bringup_test.test.py TIMEOUT 120 ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
+endif()

--- a/doc/tutorials/quickstart_in_rviz/CMakeLists.txt
+++ b/doc/tutorials/quickstart_in_rviz/CMakeLists.txt
@@ -6,13 +6,7 @@ if(BUILD_TESTING)
   find_package(ros_testing REQUIRED)
   find_package(Boost REQUIRED COMPONENTS filesystem)
 
-  # These don't pass yet, disable them for now
-  set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
-  set(ament_cmake_flake8_FOUND TRUE)
-  set(ament_cmake_uncrustify_FOUND TRUE)
-
-  # Run all lint tests in package.xml except those listed above
+  # Run all lint tests in package.xml
   ament_lint_auto_find_test_dependencies()
 
   # Basic "quickstart_in_rviz" bringup test

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -101,20 +101,29 @@ def generate_launch_description():
         output="both",
     )
 
-    # Load controllers
-    load_controllers = []
-    for controller in [
-        "panda_arm_controller",
-        "panda_hand_controller",
-        "joint_state_broadcaster",
-    ]:
-        load_controllers += [
-            ExecuteProcess(
-                cmd=["ros2 run controller_manager spawner {}".format(controller)],
-                shell=True,
-                output="screen",
-            )
-        ]
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "joint_state_broadcaster",
+            "--controller-manager-timeout",
+            "300",
+            "--controller-manager",
+            "/controller_manager",
+        ],
+    )
+
+    arm_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["panda_arm_controller", "-c", "/controller_manager"],
+    )
+
+    hand_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["panda_hand_controller", "-c", "/controller_manager"],
+    )
 
     return LaunchDescription(
         [
@@ -125,6 +134,8 @@ def generate_launch_description():
             robot_state_publisher,
             run_move_group_node,
             ros2_control_node,
+            joint_state_broadcaster_spawner,
+            arm_controller_spawner,
+            hand_controller_spawner,
         ]
-        + load_controllers
     )

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -24,6 +24,7 @@ def generate_launch_description():
         .planning_scene_monitor(
             publish_robot_description=True, publish_robot_description_semantic=True
         )
+        .planning_pipelines(pipelines=["ompl"])
         .to_moveit_configs()
     )
 

--- a/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
+++ b/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
@@ -71,25 +71,6 @@ TEST_F(BringupTestFixture, BasicBringupTest)
   auto move_group_client = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(node_, "/move_action");
   EXPECT_TRUE(move_group_client->wait_for_action_server());
 
-  // Check for the expected nodes
-  const auto actual_node_names = node_->get_node_names();
-  const std::vector<std::string> expected_node_names{
-    "/controller_manager",
-    "/joint_state_broadcaster",
-    "/move_group",
-    "/moveit_simple_controller_manager",
-    "/panda_arm_controller",
-    "/panda_hand_controller",
-    "/robot_state_publisher",
-    // TODO(andyz): rviz cannot launch in CI
-    //"/rviz2"
-  };
-  for (const std::string& node_name : expected_node_names)
-  {
-    RCLCPP_INFO_STREAM(LOGGER, "Looking for node name " << node_name);
-    EXPECT_NE(std::find(actual_node_names.begin(), actual_node_names.end(), node_name), actual_node_names.end());
-  }
-
   // Send a trajectory request
   trajectory_msgs::msg::JointTrajectory traj_msg;
   traj_msg.joint_names = { "panda_joint1", "panda_joint2", "panda_joint3", "panda_joint4",

--- a/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
+++ b/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
@@ -26,6 +26,11 @@ make_node(std::string const& name, rclcpp::NodeOptions const& options)
 
 namespace moveit2_tutorials::quickstart_in_rviz
 {
+namespace
+{
+const rclcpp::Logger LOGGER = rclcpp::get_logger("bringup_test");
+}
+
 class BringupTestFixture : public testing::Test
 {
 public:
@@ -67,16 +72,20 @@ TEST_F(BringupTestFixture, BasicBringupTest)
 
   // Check for the expected nodes
   const auto actual_node_names = node_->get_node_names();
-  const std::vector<std::string> expected_node_names{ "/controller_manager",
-                                                      "/joint_state_broadcaster",
-                                                      "/move_group",
-                                                      "/moveit_simple_controller_manager",
-                                                      "/panda_arm_controller",
-                                                      "/panda_hand_controller",
-                                                      "/robot_state_publisher",
-                                                      "/rviz2" };
+  const std::vector<std::string> expected_node_names{
+    "/controller_manager",
+    "/joint_state_broadcaster",
+    "/move_group",
+    "/moveit_simple_controller_manager",
+    "/panda_arm_controller",
+    "/panda_hand_controller",
+    "/robot_state_publisher",
+    // TODO(andyz): rviz cannot launch in CI
+    //"/rviz2"
+  };
   for (const std::string& node_name : expected_node_names)
   {
+    RCLCPP_INFO_STREAM(LOGGER, "Looking for node name " << node_name);
     EXPECT_NE(std::find(actual_node_names.begin(), actual_node_names.end(), node_name), actual_node_names.end());
   }
 }

--- a/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
+++ b/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
@@ -1,0 +1,92 @@
+// Description: Test if launching the demo is successful
+
+#include <control_msgs/action/follow_joint_trajectory.hpp>
+#include <moveit_msgs/action/move_group.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+
+#include <gtest/gtest.h>
+#include <stdlib.h>
+
+namespace
+{
+// This is a bit of a hack to make thread sanitizer ignore a race condition
+// in the constructor of the rclcpp::Node
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+__attribute__((no_sanitize("thread")))
+#endif
+#endif
+rclcpp::Node::SharedPtr
+make_node(std::string const& name, rclcpp::NodeOptions const& options)
+{
+  return std::make_shared<rclcpp::Node>(name, options);
+}
+}  // namespace
+
+namespace moveit2_tutorials::quickstart_in_rviz
+{
+class BringupTestFixture : public testing::Test
+{
+public:
+  BringupTestFixture()
+    : node_(std::make_shared<rclcpp::Node>("basic_bringup_test"))
+    , executor_(std::make_shared<rclcpp::executors::MultiThreadedExecutor>())
+  {
+  }
+
+  void SetUp() override
+  {
+    executor_->add_node(node_);
+    executor_thread_ = std::thread([this]() { this->executor_->spin(); });
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (executor_thread_.joinable())
+    {
+      executor_thread_.join();
+    }
+  }
+
+protected:
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Executor::SharedPtr executor_;
+  std::thread executor_thread_;
+};
+
+TEST_F(BringupTestFixture, BasicBringupTest)
+{
+  // Check for several expected action servers
+  auto control_client = rclcpp_action::create_client<control_msgs::action::FollowJointTrajectory>(
+      node_, "/panda_arm_controller/follow_joint_trajectory");
+  EXPECT_TRUE(control_client->wait_for_action_server());
+  auto move_group_client = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(node_, "/move_action");
+  EXPECT_TRUE(move_group_client->wait_for_action_server());
+
+  // Check for the expected nodes
+  const auto actual_node_names = node_->get_node_names();
+  const std::vector<std::string> expected_node_names{ "/controller_manager",
+                                                      "/joint_state_broadcaster",
+                                                      "/move_group",
+                                                      "/moveit_simple_controller_manager",
+                                                      "/panda_arm_controller",
+                                                      "/panda_hand_controller",
+                                                      "/robot_state_publisher",
+                                                      "/rviz2" };
+  for (const std::string& node_name : expected_node_names)
+  {
+    EXPECT_NE(std::find(actual_node_names.begin(), actual_node_names.end(), node_name), actual_node_names.end());
+  }
+}
+}  // namespace moveit2_tutorials::quickstart_in_rviz
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/doc/tutorials/quickstart_in_rviz/test/bringup_test.test.py
+++ b/doc/tutorials/quickstart_in_rviz/test/bringup_test.test.py
@@ -1,0 +1,66 @@
+import unittest
+
+import launch
+import launch_testing
+
+# -*- coding: utf-8 -*-
+from ament_index_python.packages import get_package_share_directory
+from launch.actions import (
+    IncludeLaunchDescription,
+    TimerAction,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+
+
+def generate_test_description():
+
+    # Launch the tutorial demo
+    demo_path = (
+        get_package_share_directory("moveit2_tutorials") + "/launch/demo.launch.py"
+    )
+    base_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(demo_path),
+    )
+
+    # Launch the test
+    bringup_test = Node(
+        executable=launch.substitutions.PathJoinSubstitution(
+            [
+                launch.substitutions.LaunchConfiguration("test_binary_dir"),
+                "bringup_test",
+            ]
+        ),
+        output="screen",
+    )
+
+    return launch.LaunchDescription(
+        [
+            launch.actions.DeclareLaunchArgument(
+                name="test_binary_dir",
+                description="Binary directory of package "
+                "containing test executables",
+            ),
+            base_launch,
+            # The test itself
+            bringup_test,
+            TimerAction(period=2.0, actions=[bringup_test]),
+            launch_testing.actions.ReadyToTest(),
+        ]
+    ), {
+        "bringup_test": bringup_test,
+    }
+
+
+class TestGTestWaitForCompletion(unittest.TestCase):
+    # Waits for test to complete
+    # Then waits a bit to make sure result files are generated
+    def test_gtest_run_complete(self, bringup_test):
+        self.proc_info.assertWaitForShutdown(bringup_test, timeout=4000.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+    # Checks if the test has been completed with acceptable exit codes
+    def test_gtest_pass(self, proc_info, bringup_test):
+        launch_testing.asserts.assertExitCodes(proc_info, process=bringup_test)


### PR DESCRIPTION
### Description

This adds an integration test for the first tutorial presented to new users: [MoveIt Quickstart in RViz](https://moveit.picknik.ai/main/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html). It checks that the expected nodes and action servers are available.

I think this type of test is great to have, especially on the entry point to MoveIt for most new users. There are quite a few issues this type of test would have helped to catch in the past including [[1](https://github.com/ros-planning/moveit2_tutorials/issues/385), [2](https://github.com/ros-planning/moveit2_tutorials/issues/308), [3](https://github.com/ros-planning/moveit2_tutorials/issues/193), [4](https://github.com/ros-planning/moveit_resources/pull/129)].

### Verification

You can verify the test passes locally like so:

`colcon test --packages-select moveit2_tutorials`