### PR TITLE
Mention Docker as alternative Getting Started path

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -3,6 +3,8 @@ Getting Started
 
 Here we will setup your environment for best running the tutorials. This will create a Colcon workspace, download all of the latest MoveIt source code, and build everything from source to ensure you have the latest fixes and improvements.
 
+Building all the source code of MoveIt can take 20-30 minutes, depending on the CPU speed and available RAM of your computer. If you are on a less performant system, or generally just want to get started quicker, checkout our :doc:`Docker Guide </doc/how_to_guides/how_to_setup_docker_containers_in_ubuntu>`.
+
 Install ROS 2 and Colcon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :ros_documentation:`Install ROS 2 {DISTRO_TITLE}<Installation.html>`.
@@ -42,7 +44,7 @@ For tutorials you will need to have a :ros_documentation:`colcon <Tutorials/Colc
 
 Download Source Code of MoveIt and the Tutorials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Move into your colcon workspace and pull the MoveIt tutorials source: ::
+Move into your Colcon workspace and pull the MoveIt tutorials source: ::
 
   cd ~/ws_moveit2/src
   git clone https://github.com/ros-planning/moveit2_tutorials -b main
@@ -57,19 +59,19 @@ The following will install from Debian any package dependencies not already in y
 
   rosdep install -r --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
 
-The next command will configure your colcon workspace: ::
+The next command will configure your Colcon workspace: ::
 
   cd ~/ws_moveit2
   colcon build --mixin release
 
-This build command will likely take a long time (20+ minutes) depending on your computer speed and amount of RAM available (we recommend 32 GB). If you are short on computer memory or generally your build is struggling to complete on your computer, you can append the argument ``--parallel-workers 1`` to the colcon command above.
+This build command will likely take a long time (20+ minutes) depending on your computer speed and amount of RAM available (we recommend 32 GB). If you are short on computer memory or generally your build is struggling to complete on your computer, you can append the argument ``--parallel-workers 1`` to the Colcon command above.
 
-If everything goes well, you should see the message "finished". If you have problems, try re-checking your `ROS Installation <https://docs.ros.org/en/rolling/Installation.html>`_.
+If everything goes well, you should see the message "Summary: X packages finished" where X might be 50. If you have problems, try re-checking your `ROS Installation <https://docs.ros.org/en/rolling/Installation.html>`_.
 
 Setup Your Colcon Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Source the colcon workspace: ::
+Source the Colcon workspace: ::
 
   source ~/ws_moveit2/install/setup.bash
 
@@ -79,7 +81,7 @@ Optional: add the previous command to your ``.bashrc``: ::
 
 .. note:: Sourcing the ``setup.bash`` automatically in your ``~/.bashrc`` is
    not required and often skipped by advanced users who use more than one
-   colcon workspace at a time, but we recommend it for simplicity.
+   Colcon workspace at a time, but we recommend it for simplicity.
 
 Next Step
 ^^^^^^^^^


### PR DESCRIPTION
It is hard and slow to install all of MoveIt from source in the Getting Started tutorial, so @vatanaksoytezer recommended [in this discussion](https://github.com/ros-planning/moveit2_tutorials/issues/404) we also mention the availability of pre-made Docker files.