### PR TITLE
Clarify where the motion planning timeout comes from

### DIFF
--- a/doc/examples/ompl_interface/ompl_interface_tutorial.rst
+++ b/doc/examples/ompl_interface/ompl_interface_tutorial.rst
@@ -111,7 +111,7 @@ configuration in ompl_planning.yaml via the ``termination_condition`` parameter.
 * ``CostConvergence[solutionsWindow,epsilon]``: Terminate after the cost (as specified by an optimization objective) has converged. The parameter ``solutionsWindow`` specifies the minimum number of solutions to use in deciding whether a planner has converged. The parameter ``epsilon`` is the threshold to consider for convergence. This should be a positive number close to 0. If the cumulative moving average does not change by a relative fraction of epsilon after a new better solution is found, convergence has been reached. *This termination condition is only available in OMPL 1.5.0 and newer.*
 * ``ExactSolution``: Terminate as soon as an exact solution is found or a timeout occurs. This modifies the behavior of anytime/optimizing planners to terminate upon discovering the first feasible solution.
 
-In all cases, the planner will terminate when either the user-specified termination condition is satisfied or the time limit specified by ``timeout`` has been reached, whichever occurs first.
+In all cases, the planner will terminate when either the user-specified termination condition is satisfied or the ``allowed_planning_time`` in the MotionPlanRequest message has been reached, whichever occurs first.
 
 For example, to specify that RRTstar should terminate upon convergence, the following settings could be used: ::
 


### PR DESCRIPTION
This should fix https://github.com/ros-planning/moveit2/issues/1321 (the wording confused me).