### PR TITLE
Fix grammar nits

### DIFF
--- a/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
+++ b/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
@@ -112,7 +112,7 @@ After we've constructed and initialized, we now create some closures (function o
 
 .. code-block:: C++
 
-    // Create a closures for visualization
+    // Create closures for visualization
     auto const draw_title = [&moveit_visual_tools](auto text) {
       auto const text_pose = [] {
         auto msg = Eigen::Isometry3d::Identity();

--- a/doc/tutorials/your_first_project/your_first_project.rst
+++ b/doc/tutorials/your_first_project/your_first_project.rst
@@ -200,7 +200,7 @@ If it fails to find that within 10 seconds, it prints this error and terminates 
 
 The first thing we do is create the MoveGroupInterface. This object will be used to interact with move_group, which allows us to plan and execute trajectories.
 Note that this is the only mutable object that we create in this program.
-Another thing to take note of is the second interface to the ``MoveGroupInterface`` object we are creating here: ``"panda_arm"``.
+Another thing to take note of is the second argument to the ``MoveGroupInterface`` object we are creating here: ``"panda_arm"``.
 That is the group of joints as defined in the robot description that we are going to operate on with this ``MoveGroupInterface``.
 
 .. code-block:: C++


### PR DESCRIPTION
### Description

Split off from #422 (and thus #404) per @vatanaksoytezer - found and fixed a couple small grammar errors in the tutorials.  

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
