### PR TITLE
Updated the pick and place documentation to note deprecated functionality

### DIFF
--- a/doc/examples/pick_place/pick_place_tutorial.rst
+++ b/doc/examples/pick_place/pick_place_tutorial.rst
@@ -6,6 +6,8 @@
 Pick and Place
 ==============
 
+**NOTE:** The functionality used in this tutorial is deprecated. To perform a pick and place operation, MoveIt Task Constructor (MTC) should be used (`Pick and Place with MoveIt Task Constructor <https://moveit.picknik.ai/humble/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.html>`_). More information on the MoveIt Task Constructor can be found `here. <https://moveit.picknik.ai/humble/doc/examples/moveit_task_constructor/moveit_task_constructor_tutorial.html>`_
+
 In MoveIt, grasping is done using the MoveGroup interface. In order to grasp an object we need to create ``moveit_msgs::Grasp`` msg which will allow defining the various poses and postures involved in a grasping operation.
 Watch this video to see the output of this tutorial:
 


### PR DESCRIPTION
### Description

This update to the pick and place documentation notes that the pick and place functionality from MoveIt1 is deprecated and that the current method of doing a pick and place operation it to use the MoveIt Task Constructor. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
