### PR TITLE
Add explanation about IK plugins for servo

### DIFF
--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -115,6 +115,7 @@ To configure an IK plugin for use in Servo, your robot config package must defin
 in the `Panda config package <https://github.com/ros-planning/moveit_resources/blob/master/panda_moveit_config/config/kinematics.yaml>`_.
 Several IK plugins are available `within MoveIt <https://github.com/ros-planning/moveit2/tree/main/moveit_kinematics>`_,
 as well as `externally <https://github.com/PickNikRobotics/bio_ik/tree/ros2>`_.
+`bio_ik/BioIKKinematicsPlugin` is the most common choice.
 
 Once your :code:`kinematics.yaml` file has been populated, include it with the ROS parameters passed to the servo node in your launch file:
 

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -107,6 +107,40 @@ Servo includes a number of nice features:
     5. Joint position and velocity limits enforced
     6. Inputs are generic ROS messages
 
+Inverse Kinematics in Servo
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Inverse Kinematics may be handled internally by MoveIt Servo via inverse Jacobian calculations. However, you may also use an IK plugin.
+To configure an IK plugin for use in Servo, your robot config package must define one in a :code:`kinematics.yaml` file, such as the one
+in the `Panda config package <https://github.com/ros-planning/moveit_resources/blob/master/panda_moveit_config/config/kinematics.yaml>`_.
+Several IK plugins are available `within MoveIt <https://github.com/ros-planning/moveit2/tree/main/moveit_kinematics>`_,
+as well as `externally <https://github.com/PickNikRobotics/bio_ik/tree/ros2>`_.
+
+Once your :code:`kinematics.yaml` file has been populated, include it with the ROS parameters passed to the servo node in your launch file:
+
+.. code-block:: python
+
+    moveit_config = (
+        MoveItConfigsBuilder("moveit_resources_panda")
+        .robot_description(file_path="config/panda.urdf.xacro")
+        .to_moveit_configs()
+    )
+    servo_node = Node(
+        package="moveit_servo",
+        executable="servo_node_main",
+        parameters=[
+            servo_params,
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.robot_description_kinematics, # here is where kinematics plugin parameters are passed
+        ],
+    )
+
+
+The above excerpt is taken from `servo_example.launch.py <https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/launch/servo_example.launch.py>`_ in MoveIt.
+In the above example, the :code:`kinematics.yaml` file is taken from the `moveit_resources <https://github.com/ros-planning/moveit_resources>`_ repository in the workspace, specifically :code:`moveit_resources/panda_moveit_config/config/kinematics.yaml`.
+The actual ROS parameter names that get passed by loading the yaml file are of the form :code:`robot_description_kinematics.<group_name>.<param_name>`, e.g. :code:`robot_description_kinematics.panda_arm.kinematics_solver`.
+
 Setup on a New Robot
 --------------------
 

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -115,7 +115,7 @@ To configure an IK plugin for use in Servo, your robot config package must defin
 in the `Panda config package <https://github.com/ros-planning/moveit_resources/blob/master/panda_moveit_config/config/kinematics.yaml>`_.
 Several IK plugins are available `within MoveIt <https://github.com/ros-planning/moveit2/tree/main/moveit_kinematics>`_,
 as well as `externally <https://github.com/PickNikRobotics/bio_ik/tree/ros2>`_.
-`bio_ik/BioIKKinematicsPlugin` is the most common choice.
+:code:`bio_ik/BioIKKinematicsPlugin` is the most common choice.
 
 Once your :code:`kinematics.yaml` file has been populated, include it with the ROS parameters passed to the servo node in your launch file:
 


### PR DESCRIPTION
Following the addition of [IK plugins for moveit_servo](https://github.com/ros-planning/moveit2/pull/1434), this provides some explanation in the moveit_servo tutorial about how to configure an IK plugin.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
