### PR TITLE
Add detail on custom IK plugin param declaration.

### DIFF
--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -144,7 +144,7 @@ The actual ROS parameter names that get passed by loading the yaml file are of t
 
 Since :code:`moveit_servo` does not allow undeclared parameters found in the :code:`kinematics.yaml` file to be set on the Servo node, custom solver parameters need to be declared from inside your plugin code. 
 
-For example, :code:`bio_ik` defines a `getROSParam()` function in `bio_ik/src/kinematics_plugin.cpp <https://github.com/PickNikRobotics/bio_ik/blob/ros2/src/kinematics_plugin.cpp#L160>`_ that declares parameters if they're not found on the Servo Node. 
+For example, :code:`bio_ik` defines a :code:`getROSParam()` function in `bio_ik/src/kinematics_plugin.cpp <https://github.com/PickNikRobotics/bio_ik/blob/ros2/src/kinematics_plugin.cpp#L160>`_ that declares parameters if they're not found on the Servo Node. 
 
 Setup on a New Robot
 --------------------

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -142,7 +142,7 @@ The above excerpt is taken from `servo_example.launch.py <https://github.com/ros
 In the above example, the :code:`kinematics.yaml` file is taken from the `moveit_resources <https://github.com/ros-planning/moveit_resources>`_ repository in the workspace, specifically :code:`moveit_resources/panda_moveit_config/config/kinematics.yaml`.
 The actual ROS parameter names that get passed by loading the yaml file are of the form :code:`robot_description_kinematics.<group_name>.<param_name>`, e.g. :code:`robot_description_kinematics.panda_arm.kinematics_solver`.
 
-Since `moveit_servo` does not allow undeclared parameters found in the `kinematics.yaml` file to be set on the Servo node, custom solver parameters need to be declared from inside your plugin code. 
+Since :code:`moveit_servo` does not allow undeclared parameters found in the :code:`kinematics.yaml` file to be set on the Servo node, custom solver parameters need to be declared from inside your plugin code. 
 
 For example, :code:`bio_ik` defines a `getROSParam()` function in `bio_ik/src/kinematics_plugin.cpp <https://github.com/PickNikRobotics/bio_ik/blob/ros2/src/kinematics_plugin.cpp#L160>`_ that declares parameters if they're not found on the Servo Node. 
 

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -142,6 +142,10 @@ The above excerpt is taken from `servo_example.launch.py <https://github.com/ros
 In the above example, the :code:`kinematics.yaml` file is taken from the `moveit_resources <https://github.com/ros-planning/moveit_resources>`_ repository in the workspace, specifically :code:`moveit_resources/panda_moveit_config/config/kinematics.yaml`.
 The actual ROS parameter names that get passed by loading the yaml file are of the form :code:`robot_description_kinematics.<group_name>.<param_name>`, e.g. :code:`robot_description_kinematics.panda_arm.kinematics_solver`.
 
+Since `moveit_servo` does not allow undeclared parameters found in the `kinematics.yaml` file to be set on the Servo node, custom solver parameters need to be declared from inside your plugin code. 
+
+For example, :code:`bio_ik` defines a `getROSParam()` function in `bio_ik/src/kinematics_plugin.cpp <https://github.com/PickNikRobotics/bio_ik/blob/ros2/src/kinematics_plugin.cpp#L16>`_ that declares parameters if they're not found on the Servo Node. 
+
 Setup on a New Robot
 --------------------
 

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -144,7 +144,7 @@ The actual ROS parameter names that get passed by loading the yaml file are of t
 
 Since `moveit_servo` does not allow undeclared parameters found in the `kinematics.yaml` file to be set on the Servo node, custom solver parameters need to be declared from inside your plugin code. 
 
-For example, :code:`bio_ik` defines a `getROSParam()` function in `bio_ik/src/kinematics_plugin.cpp <https://github.com/PickNikRobotics/bio_ik/blob/ros2/src/kinematics_plugin.cpp#L16>`_ that declares parameters if they're not found on the Servo Node. 
+For example, :code:`bio_ik` defines a `getROSParam()` function in `bio_ik/src/kinematics_plugin.cpp <https://github.com/PickNikRobotics/bio_ik/blob/ros2/src/kinematics_plugin.cpp#L160>`_ that declares parameters if they're not found on the Servo Node. 
 
 Setup on a New Robot
 --------------------

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -142,9 +142,9 @@ The above excerpt is taken from `servo_example.launch.py <https://github.com/ros
 In the above example, the :code:`kinematics.yaml` file is taken from the `moveit_resources <https://github.com/ros-planning/moveit_resources>`_ repository in the workspace, specifically :code:`moveit_resources/panda_moveit_config/config/kinematics.yaml`.
 The actual ROS parameter names that get passed by loading the yaml file are of the form :code:`robot_description_kinematics.<group_name>.<param_name>`, e.g. :code:`robot_description_kinematics.panda_arm.kinematics_solver`.
 
-Since :code:`moveit_servo` does not allow undeclared parameters found in the :code:`kinematics.yaml` file to be set on the Servo node, custom solver parameters need to be declared from inside your plugin code. 
+Since :code:`moveit_servo` does not allow undeclared parameters found in the :code:`kinematics.yaml` file to be set on the Servo node, custom solver parameters need to be declared from inside your plugin code.
 
-For example, :code:`bio_ik` defines a :code:`getROSParam()` function in `bio_ik/src/kinematics_plugin.cpp <https://github.com/PickNikRobotics/bio_ik/blob/ros2/src/kinematics_plugin.cpp#L160>`_ that declares parameters if they're not found on the Servo Node. 
+For example, :code:`bio_ik` defines a :code:`getROSParam()` function in `bio_ik/src/kinematics_plugin.cpp <https://github.com/PickNikRobotics/bio_ik/blob/ros2/src/kinematics_plugin.cpp#L160>`_ that declares parameters if they're not found on the Servo Node.
 
 Setup on a New Robot
 --------------------


### PR DESCRIPTION
### Description

It looks like MoveIt Servo does not use the `automatically_declare_parameters_from_overrides` machinery discussed here:

https://github.com/orgs/ros-planning/discussions/1486

This seems to mean that, unlike a `move_group` node, a kinematics plugin loaded by Servo is responsible for declaring any custom parameters it needs to read from the corresponding MoveIt Config's `kinematics.yaml`. 

Maybe this is somehow not the case for configs generated with `MoveItConfigsBuilder`, but it was my experience working on a custom kinematics plugin and modifying the `ur_moveit_config` launch file used by the Universal Robots ROS2 Driver:

https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main/ur_moveit_config

I added some text to the "Inverse Kinematics in Servo" section to point at `bio_ik` as an existing example of how to declare parameters so that they can be read from `kinematics.yaml`. 

Otherwise it seems like the only parameters passed through to the Servo node are:
 - `robot_description_kinematics.ur_manipulator.kinematics_solver`, 
 - `robot_description_kinematics.ur_manipulator.kinematics_solver_search_resolution`
 - `robot_description_kinematics.ur_manipulator.kinematics_solver_timeout` 

(In contrast I can add arbitrary parameters to `ur_manipulator` in the YAML file and retrieve them from the same plugin loaded into a `move_group` node)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
