### PR TITLE
Update hybrid_planning_tutorial.rst , launchfile needs to import plugin differently

### DIFF
--- a/doc/examples/hybrid_planning/hybrid_planning_tutorial.rst
+++ b/doc/examples/hybrid_planning/hybrid_planning_tutorial.rst
@@ -55,7 +55,7 @@ To include the Hybrid Planning Architecture into you project you need to add a *
         composable_node_descriptions=[
             ComposableNode(
                 package="moveit_hybrid_planning",
-                plugin="moveit_hybrid_planning::GlobalPlannerComponent",
+                plugin="moveit::hybrid_planning::GlobalPlannerComponent",
                 name="global_planner",
                 parameters=[
                     global_planner_param,
@@ -67,7 +67,7 @@ To include the Hybrid Planning Architecture into you project you need to add a *
             ),
             ComposableNode(
                 package="moveit_hybrid_planning",
-                plugin="moveit_hybrid_planning::LocalPlannerComponent",
+                plugin="moveit::hybrid_planning::LocalPlannerComponent",
                 name="local_planner",
                 parameters=[
                     local_planner_param,
@@ -78,7 +78,7 @@ To include the Hybrid Planning Architecture into you project you need to add a *
             ),
             ComposableNode(
                 package="moveit_hybrid_planning",
-                plugin="moveit_hybrid_planning::HybridPlanningManager",
+                plugin="moveit::hybrid_planning::HybridPlanningManager",
                 name="hybrid_planning_manager",
                 parameters=[hybrid_planning_manager_param],
             ),


### PR DESCRIPTION
### Description

The classes cannot be found if the plugin import was written like in the tutorial. 

```
[ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'global_planner' of type 'moveit_hybrid_planning::GlobalPlannerComponent' in container '/hybrid_planning_container': Failed to find class with the requested plugin name.
[component_container-5] [ERROR] [1661345481.458624976] [hybrid_planning_container]: Failed to find class with the requested plugin name 'moveit_hybrid_planning::GlobalPlannerComponent' in the loaded library
[component_container-5] [ERROR] [1661345481.470274994] [hybrid_planning_container]: Failed to find class with the requested plugin name 'moveit_hybrid_planning::LocalPlannerComponent' in the loaded library
[ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'local_planner' of type 'moveit_hybrid_planning::LocalPlannerComponent' in container '/hybrid_planning_container': Failed to find class with the requested plugin name.
[ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'hybrid_planning_manager' of type 'moveit_hybrid_planning::HybridPlanningManager' in container '/hybrid_planning_container': Failed to find class with the requested plugin name.
[component_container-5] [ERROR] [1661345481.480689611] [hybrid_planning_container]: Failed to find class with the requested plugin name 'moveit_hybrid_planning::HybridPlanningManager' in the loaded library
```

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
