### PR TITLE
Shallow clone of tutorials repo

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -47,7 +47,7 @@ Download Source Code of MoveIt and the Tutorials
 Move into your Colcon workspace and pull the MoveIt tutorials source: ::
 
   cd ~/ws_moveit/src
-  git clone https://github.com/ros-planning/moveit2_tutorials -b main
+  git clone https://github.com/ros-planning/moveit2_tutorials -b main --depth 1
 
 Next we will download the source code for the rest of MoveIt: ::
 


### PR DESCRIPTION
### Description

This will speed up people following the tutorials. I suspect the reason this repo is so huge is the gh_pages branch that contains all the generated API docs now is taking up a ton of space. Until we figure out how to work around that here is a fix for users.

