### PR TITLE
moveit_py API documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,17 +16,16 @@ permissions:
 jobs:
   htmlproofer:
     runs-on: ubuntu-latest
+    container:
+      image: moveit/moveit2:rolling-source
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
-        cache: 'pip'
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install --upgrade --requirement requirements.txt
+        sudo apt-get update -y
+        sudo apt-get install -y python3-pip
+        pip3 install --upgrade --requirement requirements.txt
 
     - name: Install doxygen and graphviz
       run: sudo apt-get install -y doxygen graphviz
@@ -36,10 +35,56 @@ jobs:
         ruby-version: '2.7'
 
     - name: Run htmlproofer.sh
-      run: ./htmlproofer.sh
+      shell: bash
+      run: |
+        source /opt/ros/rolling/setup.bash
+        source /root/ws_moveit/install/setup.bash
+        ./htmlproofer.sh
 
-  multiversion-with-api:
+  upload_site_artifacts:
+    strategy:
+      matrix:
+        include:
+          - container: 'moveit/moveit2:rolling-source'
+            branch: 'main'
+            rosdistro: 'rolling'
+          - container: 'moveit/moveit2:humble-source'
+            branch: 'humble'
+            rosdistro: 'humble'
     runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Python dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y python3-pip
+        pip3 install --upgrade --requirement requirements.txt
+
+    - name: Install doxygen and graphviz
+      run: sudo apt-get install -y doxygen graphviz
+
+    - name: Build Sphinx Artifacts
+      shell: bash
+      run: |
+        source /opt/ros/${{ matrix.rosdistro }}/setup.bash
+        source /root/ws_moveit/install/setup.bash
+        make generate_api_artifacts BRANCH=${{ matrix.branch }}
+
+    - name: Compress Artifact
+      run: tar cvzf artifact.tar.gz build/html
+
+    - name: Upload HTML Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: '${{ matrix.branch }}_html_artifacts'
+        path: artifact.tar.gz
+
+  collate_site_artifacts:
+    runs-on: ubuntu-latest
+    needs: upload_site_artifacts
     steps:
     - uses: actions/checkout@v3
       with:
@@ -62,11 +107,34 @@ jobs:
       with:
         ruby-version: '2.7'
 
-    - name: Build multiversion with API
-      run: make multiversion-with-api
+    # TODO (peterdavidfagan): don't hardcode branches for downloads
+    - name: Download Rolling Artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: main_html_artifacts
+        path: build/html/main
+
+    - name: Decompress Rolling Artifact
+      run: |
+        tar -xf build/html/main/artifact.tar.gz
+        rm build/html/main/artifact.tar.gz
+
+    - name: Download Humble Artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: humble_html_artifacts
+        path: build/html/humble
+
+    - name: Decompress Humble Artifact
+      run: |
+        tar -xf build/html/humble/artifact.tar.gz
+        rm build/html/humble/artifact.tar.gz
 
     - name: Create CNAME file
       run: echo "moveit.picknik.ai" > build/html/CNAME
+
+    - name: Build multiversion
+      run: make multiversion
 
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v1
@@ -77,7 +145,7 @@ jobs:
   deploy:
     if: github.repository_owner == 'ros-planning' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: multiversion-with-api
+    needs: collate_site_artifacts
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,6 @@ multiversion: Makefile
 	sphinx-multiversion $(OPTS) "$(SOURCE)" build/html
 	@echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=humble/index.html\" /></head></html>" > build/html/index.html
 
-multiversion-with-api: Makefile
-	@echo Building multiversion with API
-	@echo Step 1 of 2: Clone MoveIt 2 and build API for all distros
-	for branch in main humble ; do \
-	  mkdir -p build/html/$$branch; cd build/html/$$branch && if cd moveit2; then git pull; else git clone https://github.com/ros-planning/moveit2 -b $$branch --depth 1 && cd moveit2; fi && \
-	  sed -i "s/HTML_EXTRA_STYLESHEET  =.*/HTML_EXTRA_STYLESHEET  = ..\/..\/..\/..\/theme.css/g" Doxyfile && DOXYGEN_OUTPUT_DIRECTORY="../api" doxygen && cd .. && rm -rf moveit2 ; cd ../../..; \
-	done
-	@echo Step 2 of 2: Building multiversion
-	sphinx-multiversion $(OPTS) "$(SOURCE)" build/html
-	@echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=humble/index.html\" /></head></html>" > build/html/index.html
-
 local-with-api: Makefile
 	@echo Building local with API
 	@echo Step 1 of 2: Clone MoveIt 2 and build API using selected distro
@@ -33,7 +22,18 @@ local-with-api: Makefile
 	@echo Step 2 of 2: Building html
 	make html
 
-.PHONY: help local-with-api Makefile multiversion multiversion-with-api
+# intended to be leveraged for CI only
+generate_api_artifacts: Makefile
+	@echo Building Python API Artifacts
+	@echo Step 1 of 3: Ensure build folder exists
+	mkdir -p build/html
+	@echo Step 2 of 3: generate CPP API Artifacts
+	cd build/html && if cd moveit2; then git pull; else git clone https://github.com/ros-planning/moveit2 -b $(BRANCH) --depth 1 && cd moveit2; fi && \
+	sed -i "s/HTML_EXTRA_STYLESHEET  =.*/HTML_EXTRA_STYLESHEET  = ..\/..\/..\/theme.css/g" Doxyfile && DOXYGEN_OUTPUT_DIRECTORY="../api" doxygen &&  cd .. && rm -rf moveit2
+	@echo Step 3 of 3: Build Sphinx Artifacts
+	make html
+
+.PHONY: help local-with-api Makefile multiversion multiversion-with-api generate_api_artifacts
 
 # By default this is the 'html' build
 %: Makefile

--- a/build_locally.sh
+++ b/build_locally.sh
@@ -1,6 +1,11 @@
 #!/bin/bash -eu
-
 export MOVEIT_BRANCH=main
+export ROS_DISTRO=rolling
+python_version=$(python --version 2>&1 | tr -d ' ' | tr '[:upper:]' '[:lower:]' | sed 's/\.[0-9]*$//')
+
+# path variables required to build Python API documentation
+export PYTHONPATH=/opt/ros/$ROS_DISTRO/lib/$python_version/site-packages:/opt/ros/$ROS_DISTRO/local/lib/$python_version/dist-packages
+export LD_LIBRARY_PATH=/opt/ros/$ROS_DISTRO/lib
 
 have_loop() {
   for arg in "$@"; do

--- a/conf.py
+++ b/conf.py
@@ -81,6 +81,9 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.ifconfig",
     "sphinx_copybutton",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
 ]
 
 autosectionlabel_prefix_document = True
@@ -250,6 +253,30 @@ extlinks = {
 # Only used for local build, multiversion overwrites this in the smv_rewrite_configs() function
 doxylink = {"cpp_api": ("build/html/api/MoveIt.tag", "api/html")}
 add_function_parentheses = True
+
+
+autodoc_typehints = "signature"
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+    "member-order": "bysource",
+}
+
+autosummary_generate = True
+
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = False
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = False
+napoleon_use_rtype = False
 
 
 class RedirectFrom(Directive):

--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -1,6 +1,7 @@
 API Documentation
 =================
+.. toctree::
+   :maxdepth: 1
 
-.. raw:: html
-
-    <meta http-equiv="Refresh" content="0; url='../../api/html/index.html" />
+   cpp_api/api
+   python_api/api

--- a/doc/api/cpp_api/api.rst
+++ b/doc/api/cpp_api/api.rst
@@ -1,0 +1,6 @@
+C++ API Documentation
+=====================
+
+.. raw:: html
+
+    <meta http-equiv="Refresh" content="0; url='../../../api/html/index.html" />

--- a/doc/api/python_api/api.rst
+++ b/doc/api/python_api/api.rst
@@ -1,0 +1,19 @@
+Python API Documentation
+=====================================
+
+.. toctree::
+
+.. autosummary::
+   :toctree: _autosummary
+   :recursive:
+
+   moveit.core.collision_detection
+   moveit.core.controller_manager
+   moveit.core.kinematic_constraints
+   moveit.core.planning_interface
+   moveit.core.planning_scene
+   moveit.core.robot_model
+   moveit.core.robot_state
+   moveit.core.robot_trajectory
+   moveit.planning
+   moveit.servo_client

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -40,8 +40,9 @@ grep -rl 'https:\/\/moveit.picknik.ai\/rolling\/' ./build/ | \
  xargs sed -i "s|https://moveit.picknik.ai/rolling/|file://$PWD|g"
 
 # Run HTML tests on generated build output to check for 404 errors, etc
+# 429 or 403 - happens when GitHub rate-limits requests
 htmlproofer ./build \
-  --only-4xx --check-html --http-status-ignore "429" \
+  --only-4xx --check-html --http-status-ignore "429" --http-status-ignore "403" \
   --file-ignore ./build/html/genindex.html,./build/html/search.html,/html/api/ \
   --alt-ignore '/.*/' --url-ignore '#'
 


### PR DESCRIPTION
### Description

This pull request adds API documentation for the MoveItPy library. A sample of the documentation when built locally is provided below. Further changes are required to ensure the code in this pull request is compatible with CI tests. At the moment, to build locally you must have built and be able to import the moveit_py library in order for sphinx.ext.autodoc to generate the required documentation.

### Changes
- Generate and upload artifacts for website branches within a docker container (remove headache of configuring Python package installation)
- Download and collate artifacts in subsequent job, upload final website artifact to be deployed
- Deprecate multiversion-with-api


[Screencast from 09-01-2022 08:37:49 PM.webm](https://user-images.githubusercontent.com/42982057/187999821-764fe047-2a7d-4809-ab34-7fe400330e66.webm)


