### PR TITLE
Add note about switching middlewares (to CycloneDDS)

### DIFF
--- a/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
+++ b/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
@@ -270,6 +270,7 @@ To continue, press ``Next`` again to see your robot execute the plan.
 
 .. image:: executing.png
 
+.. note:: The robot may have no response at this step. Following the next method should solve the problem. - Change your default DDS to CycloneDDS and restart your terminal. - Move the MGI initialization before the SingleThreadedExecutor in ``hello_moveit.cpp``. - Rebuild your package and run the Program. More details about this issue could be found `here <https://github.com/ros-planning/moveit2_tutorials/issues/502>`_ and `here <https://github.com/ros-planning/moveit2/issues/1474>`_.
 
 Summary
 -------

--- a/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
+++ b/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
@@ -270,7 +270,7 @@ To continue, press ``Next`` again to see your robot execute the plan.
 
 .. image:: executing.png
 
-.. note:: The robot may have no response at this step. Following the next method should solve the problem. - Change your default DDS to CycloneDDS and restart your terminal. - Move the MGI initialization before the SingleThreadedExecutor in ``hello_moveit.cpp``. - Rebuild your package and run the Program. More details about this issue could be found `here <https://github.com/ros-planning/moveit2_tutorials/issues/502>`_ and `here <https://github.com/ros-planning/moveit2/issues/1474>`_.
+.. note:: If the robot does not move, you may need to switch to CycloneDDS middleware, as described in :doc:`Getting Started </doc/tutorials/getting_started/getting_started>`.
 
 Summary
 -------


### PR DESCRIPTION
### Description
Execution phase of the Step Visualizing_in_rviz may fail due to the default middlewares. Switching it to CycloneDDS can solve the problem.
I add some notes so more people can see it.
More details are discussed here:[https://github.com/ros-planning/moveit2/issues/1474#issuecomment-1227509627](url)