### PR TITLE
Update ros2_control version to pull in chained controllers information

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -26,4 +26,4 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: 2.12.1
+    version: 2.13.0


### PR DESCRIPTION
### Description

Addresses https://github.com/ros-planning/moveit2_tutorials/issues/511

This change to support chained controllers https://github.com/ros-planning/moveit2/pull/1482 relies on the updated msg format from [ros2_control](https://github.com/ros-controls/ros2_control/commit/94d1e9a9f07c92094992d26c44ac8d9e0a3c9103#diff-ff07c5d9557e55b54b7db28eb20db07c45d7b1f340a784dd1178d704eed2776b).

Otherwise we end up with build errors,

```
ws_moveit2/src/moveit2/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp:471:22: error: ‘struct controller_manager_msgs::msg::ControllerState_<std::allocator<void> >’ has no member named ‘chain_connections’
  471 |       if (controller.chain_connections.size() > 1)
      |                      ^~~~~~~~~~~~~~~~~

```

Updating ros2_control target version to match what is currently in [moveit2](https://github.com/ros-planning/moveit2/blob/main/moveit2.repos#L10).