### PR TITLE
Fix launching of the Quickstart tutorial

### DIFF
--- a/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -14,7 +14,7 @@ Step 1: Launch the Demo and Configure the Plugin
 
 * Launch the demo: ::
 
-   ros2 launch moveit2_tutorials demo.launch.py rviz_tutorial:=true
+   ros2 launch moveit2_tutorials demo.launch.py
 
 * If you are doing this for the first time, you should see an empty world in RViz and will have to add the Motion Planning Plugin:
 


### PR DESCRIPTION
### Description

Fix several issues with this tutorial:  https://moveit.picknik.ai/humble/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html

- Launching failed:

`[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught exception when trying to load file of format [py]: 'robot_description_planning'`

- The `tutorial_arg` argument was not actually used. You can verify this with `grep -r tutorial_arg` on the main branch

Yay for an integration test that caught this!