### PR TITLE
Explicitly state which planning pipelines to use in demo launch

### DIFF
--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -15,6 +15,7 @@ def generate_launch_description():
         MoveItConfigsBuilder("moveit_resources_panda")
         .robot_description(file_path="config/panda.urdf.xacro")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
+        .planning_pipelines(pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"])
         .to_moveit_configs()
     )
 

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -15,7 +15,9 @@ def generate_launch_description():
         MoveItConfigsBuilder("moveit_resources_panda")
         .robot_description(file_path="config/panda.urdf.xacro")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
-        .planning_pipelines(pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"])
+        .planning_pipelines(
+            pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"]
+        )
         .to_moveit_configs()
     )
 


### PR DESCRIPTION
### Description
The launch file included with the Quickstart in RViz tutorial uses MoveItConfigsUtils with the panda config files in moveit_resources. By default, MoveItConfigsUtils looks for all `_planning.yaml` files, which picks up lerp_planning.yaml and trajopt_planning.yaml. These files produce the following errors (some logs removed for brevity):

```
[ERROR] [1664267382.867870261] [moveit.ros_planning.planning_pipeline]: Exception while loading planner 'lerp_interface/LERPPlanner': According to the loaded plugin descriptions the class lerp_interface/LERPPlanner with base class type planning_interface::PlannerManager does not exist. Declared types are  chomp_interface/CHOMPPlanner ompl_interface/OMPLPlanner pilz_industrial_motion_planner/CommandPlannerAvailable plugins: chomp_interface/CHOMPPlanner, ompl_interface/OMPLPlanner, pilz_industrial_motion_planner/CommandPlanner
[ERROR] [1664267382.877819227] [moveit.ros_planning_interface.moveit_cpp]: Failed to initialize planning pipeline 'lerp'.
[ERROR] [1664267383.031895256] [moveit.ros_planning.planning_pipeline]: Exception while loading planner 'trajopt_interface/TrajOptPlanner': According to the loaded plugin descriptions the class trajopt_interface/TrajOptPlanner with base class type planning_interface::PlannerManager does not exist. Declared types are  chomp_interface/CHOMPPlanner ompl_interface/OMPLPlanner pilz_industrial_motion_planner/CommandPlannerAvailable plugins: chomp_interface/CHOMPPlanner, ompl_interface/OMPLPlanner, pilz_industrial_motion_planner/CommandPlanner
[ERROR] [1664267383.041862939] [moveit.ros_planning_interface.moveit_cpp]: Failed to initialize planning pipeline 'trajopt'.
```
This PR modifies the launch file to explicitly use only the specified planning pipelines (OMPL, CHOMP, and Pilz), with the intent to prevent the above errors.