### PR TITLE
Update Documentation of Humble

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -47,7 +47,7 @@ Download Source Code of MoveIt and the Tutorials
 Move into your Colcon workspace and pull the MoveIt tutorials source: ::
 
   cd ~/ws_moveit2/src
-  git clone https://github.com/ros-planning/moveit2_tutorials -b main --depth 1
+  git clone https://github.com/ros-planning/moveit2_tutorials -b humble --depth 1
 
 Next we will download the source code for the rest of MoveIt: ::
 

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -6,7 +6,7 @@ repositories:
   moveit2:
     type: git
     url: https://github.com/ros-planning/moveit2
-    version: main
+    version: humble
   moveit_resources:
     type: git
     url: https://github.com/ros-planning/moveit_resources


### PR DESCRIPTION
### Description

In the humble documentation the wrong branch of moveit2 is pulled, therefore the build fails. Updated documentation and moveit2_tutorials.repos to pull branch humble.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
