### PR TITLE
Rename MoveItControllerManager

### DIFF
--- a/doc/examples/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/examples/controller_configuration/controller_configuration_tutorial.rst
@@ -12,7 +12,7 @@ MoveIt typically publishes manipulator motion commands to a `JointTrajectoryCont
 
 MoveIt Controller Manager
 -------------------------
-If using the Move Group or MoveItCpp, a MoveItControllerManager (MICM) can be used to manage controller switching. The MICM can parse the joint names in any command coming from MoveIt and activate the appropriate controllers. For example, it can automatically switch between controlling two manipulators in a single joint group at once to a single manipulator. To use a MICM, just set :code:`moveit_manage_controllers = true` in the launch file. `Example MICM launch file <https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/launch/demo.launch.py>`_. Frankly, the MICM is a candidate to be deprecated soon and we do not recommend its use.
+If using the Move Group or MoveItCpp, a Ros2ControlManager (R2CM) can be used to manage controller switching. The R2CM can parse the joint names in any command coming from MoveIt and activate the appropriate controllers. For example, it can automatically switch between controlling two manipulators in a single joint group at once to a single manipulator. To use a R2CM, just set :code:`moveit_manage_controllers = true` in the launch file. `Example R2CM launch file <https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/launch/demo.launch.py>`_. Frankly, the R2CM is a candidate to be deprecated soon and we do not recommend its use.
 
 MoveIt Controller Interfaces
 ----------------------------
@@ -115,6 +115,6 @@ Controllers for Multiple Nodes
 
 (TODO: update for ROS2)
 
-MoveItMultiControllerManager can be used for more than one ros_control nodes. It works by creating several MoveItControllerManagers, one for each node. It instantiates them with their respective namespace and takes care of proper delegation. To use it must be added to the launch file. ::
+Ros2ControlMultiManager can be used for more than one ros_control nodes. It works by creating several Ros2ControlManagers, one for each node. It instantiates them with their respective namespace and takes care of proper delegation. To use it must be added to the launch file. ::
 
-  <param name="moveit_controller_manager" value="moveit_ros_control_interface::MoveItMultiControllerManager" />
+  <param name="moveit_controller_manager" value="moveit_ros_control_interface::Ros2ControlMultiManager" />

--- a/doc/examples/controller_configuration/moveit_controller_manager_example_plugin_description.xml
+++ b/doc/examples/controller_configuration/moveit_controller_manager_example_plugin_description.xml
@@ -2,7 +2,7 @@
 
   <class name="moveit_tutorials/MoveItExampleControllerManager"
          type="moveit_tutorials::MoveItExampleControllerManager"
-         base_class_type="moveit_controller_manager::MoveItControllerManager">
+         base_class_type="moveit_controller_manager::Ros2ControlManager">
     <description>
       An example controller for MoveIt. This is not functional code, but can serve as a starting point for simple controllers.
     </description>

--- a/doc/examples/controller_configuration/src/moveit_controller_manager_example.cpp
+++ b/doc/examples/controller_configuration/src/moveit_controller_manager_example.cpp
@@ -73,14 +73,14 @@ public:
   }
 };
 
-class MoveItControllerManagerExample : public moveit_controller_manager::MoveItControllerManager
+class Ros2ControlManagerExample : public moveit_controller_manager::Ros2ControlManager
 {
 public:
-  MoveItControllerManagerExample()
+  Ros2ControlManagerExample()
   {
   }
 
-  ~MoveItControllerManagerExample() override = default;
+  ~Ros2ControlManagerExample() override = default;
 
   moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string& name) override
   {
@@ -133,10 +133,9 @@ public:
   /*
    * Controllers are all active and default.
    */
-  moveit_controller_manager::MoveItControllerManager::ControllerState
-  getControllerState(const std::string& /*name*/) override
+  moveit_controller_manager::Ros2ControlManager::ControllerState getControllerState(const std::string& /*name*/) override
   {
-    moveit_controller_manager::MoveItControllerManager::ControllerState state;
+    moveit_controller_manager::Ros2ControlManager::ControllerState state;
     state.active_ = true;
     state.default_ = true;
     return state;
@@ -156,5 +155,4 @@ protected:
 
 }  // end namespace moveit_tutorials
 
-PLUGINLIB_EXPORT_CLASS(moveit_tutorials::MoveItControllerManagerExample,
-                       moveit_controller_manager::MoveItControllerManager);
+PLUGINLIB_EXPORT_CLASS(moveit_tutorials::Ros2ControlManagerExample, moveit_controller_manager::Ros2ControlManager);

--- a/doc/examples/dual_arms/dual_arm_panda_moveit_config/config/moveit_controllers.yaml
+++ b/doc/examples/dual_arms/dual_arm_panda_moveit_config/config/moveit_controllers.yaml
@@ -4,4 +4,4 @@ trajectory_execution:
   allowed_goal_duration_margin: 0.5
   allowed_start_tolerance: 0.01
 
-moveit_controller_manager: moveit_ros_control_interface/MoveItMultiControllerManager
+moveit_controller_manager: moveit_ros_control_interface/Ros2ControlMultiManager

--- a/doc/examples/dual_arms/dual_arms_tutorial.rst
+++ b/doc/examples/dual_arms/dual_arms_tutorial.rst
@@ -38,4 +38,4 @@ What Changes were required for the Dual-Arm System?
 
 - Define the controllers which MoveIt can execute trajectories with in ``moveit_controllers.yaml``. Here we have a trajectory controller for each arm.
 
-- Also in ``moveit_controllers.yaml``, define the controller management strategy MoveIt will use. The simplest option from a configuration standpoint is either ``moveit_ros_control_interface/MoveItMultiControllerManager`` or ``moveit_ros_control_interface/MoveItControllerManager``. You can also use a ``moveit_simple_controller_manager/MoveItSimpleControllerManager`` although it requires additional namespacing and additional enumeration of the joints.
+- Also in ``moveit_controllers.yaml``, define the controller management strategy MoveIt will use. The simplest option from a configuration standpoint is either ``moveit_ros_control_interface/Ros2ControlMultiManager`` or ``moveit_ros_control_interface/Ros2ControlManager``. You can also use a ``moveit_simple_controller_manager/MoveItSimpleControllerManager`` although it requires additional namespacing and additional enumeration of the joints.


### PR DESCRIPTION
Description

We had a talk about what is confusing with MoveIt controller managers in July. The only action item that came out of it was renaming MoveItControllerManager->Ros2ControlManager and MoveItMultiControllerManager->Ros2ControlMultiManager.

The reason for this is to distinguish these 2 options from the MoveItSimpleControllerManager, which is a basic action interface and should be used when ros2_control isn't involved.
Merge with...

moveit2 PR: https://github.com/ros-planning/moveit2/pull/1601
