### PR TITLE
Ros2ControlManager renaming

### DIFF
--- a/doc/examples/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/examples/controller_configuration/controller_configuration_tutorial.rst
@@ -10,9 +10,9 @@ MoveIt typically publishes manipulator motion commands to a `JointTrajectoryCont
 
 #. Note: it is not required to use :code:`ros2_control` for your robot. You could write a proprietary action interface. In practice, 99% of users choose :code:`ros2_control`.
 
-MoveIt Controller Manager
--------------------------
-If using the Move Group or MoveItCpp, a MoveItControllerManager (MICM) can be used to manage controller switching. The MICM can parse the joint names in any command coming from MoveIt and activate the appropriate controllers. For example, it can automatically switch between controlling two manipulators in a single joint group at once to a single manipulator. To use a MICM, just set :code:`moveit_manage_controllers = true` in the launch file. `Example MICM launch file <https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/launch/demo.launch.py>`_. Frankly, the MICM is a candidate to be deprecated soon and we do not recommend its use.
+MoveIt Controller Managers
+--------------------------
+The base class of controller managers is called MoveItControllerManager (MICM). One of the child classes of MICM is known as Ros2ControlManager (R2CM) and it is the best way to interface with ros2_control. The R2CM can parse the joint names in a trajectory command coming from MoveIt and activate the appropriate controllers. For example, it can automatically switch between controlling two manipulators in a single joint group at once to a single manipulator. To use a R2CM, just set :code:`moveit_manage_controllers = true` in the launch file. `Example R2CM launch file <https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/launch/demo.launch.py>`_.
 
 MoveIt Controller Interfaces
 ----------------------------
@@ -113,8 +113,6 @@ All controller names get prefixed by the namespace of their ros_control node. Fo
 Controllers for Multiple Nodes
 ------------------------------
 
-(TODO: update for ROS2)
+There is a variation on the Ros2ControlManager, the Ros2ControlMultiManager. Ros2ControlMultiManager can be used for more than one ros_control nodes. It works by creating several Ros2ControlManagers, one for each node. It instantiates them with their respective namespace and takes care of proper delegation. To use it must be added to the launch file. ::
 
-MoveItMultiControllerManager can be used for more than one ros_control nodes. It works by creating several MoveItControllerManagers, one for each node. It instantiates them with their respective namespace and takes care of proper delegation. To use it must be added to the launch file. ::
-
-  <param name="moveit_controller_manager" value="moveit_ros_control_interface::MoveItMultiControllerManager" />
+  <param name="moveit_controller_manager" value="moveit_ros_control_interface::Ros2ControlMultiManager" />

--- a/doc/examples/creating_moveit_plugins/plugin_tutorial.rst
+++ b/doc/examples/creating_moveit_plugins/plugin_tutorial.rst
@@ -98,7 +98,6 @@ MoveIt controller managers, somewhat a misnomer, are the interfaces to your cust
 
 However, for some applications you might desire a more custom controller manager. An example template for starting your custom controller manager is provided :codedir:`here <examples/controller_configuration/src/moveit_controller_manager_example.cpp>`.
 
-
 Example Constraint Sampler Plugin
 ----------------------------------
 

--- a/doc/examples/dual_arms/dual_arm_panda_moveit_config/config/moveit_controllers.yaml
+++ b/doc/examples/dual_arms/dual_arm_panda_moveit_config/config/moveit_controllers.yaml
@@ -4,4 +4,4 @@ trajectory_execution:
   allowed_goal_duration_margin: 0.5
   allowed_start_tolerance: 0.01
 
-moveit_controller_manager: moveit_ros_control_interface/MoveItMultiControllerManager
+moveit_controller_manager: moveit_ros_control_interface/Ros2ControlManager

--- a/doc/examples/dual_arms/dual_arms_tutorial.rst
+++ b/doc/examples/dual_arms/dual_arms_tutorial.rst
@@ -38,4 +38,4 @@ What Changes were required for the Dual-Arm System?
 
 - Define the controllers which MoveIt can execute trajectories with in ``moveit_controllers.yaml``. Here we have a trajectory controller for each arm.
 
-- Also in ``moveit_controllers.yaml``, define the controller management strategy MoveIt will use. The simplest option from a configuration standpoint is either ``moveit_ros_control_interface/MoveItMultiControllerManager`` or ``moveit_ros_control_interface/MoveItControllerManager``. You can also use a ``moveit_simple_controller_manager/MoveItSimpleControllerManager`` although it requires additional namespacing and additional enumeration of the joints.
+- Also in ``moveit_controllers.yaml``, define the controller management strategy MoveIt will use. The simplest option from a configuration standpoint is ``moveit_ros_control_interface/Ros2ControlManager``. You can also use a ``moveit_simple_controller_manager/MoveItSimpleControllerManager`` although it requires additional namespacing and additional enumeration of the joints.


### PR DESCRIPTION
### Description

Update the name of MoveItControllerManager -> Ros2ControlManager, per this MoveIt2 PR:

https://github.com/ros-planning/moveit2_tutorials
