### PR TITLE
Fix the formatting of Cyclone commands

### DIFF
--- a/doc/examples/visualizing_collisions/src/visualizing_collisions_tutorial.cpp
+++ b/doc/examples/visualizing_collisions/src/visualizing_collisions_tutorial.cpp
@@ -168,10 +168,9 @@ int main(int argc, char** argv)
   // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // For this tutorial we use an :codedir:`InteractiveRobot <interactivity/src/interactive_robot.cpp>`
   // object as a wrapper that combines a robot_model with the cube and an interactive marker. We also
-  // create a :planning_scene:`PlanningScene` for collision checking. If you haven't already gone through the
+  // create a PlanningScene for collision checking. If you haven't already gone through the
   // :doc:`planning scene tutorial </doc/examples/planning_scene/planning_scene_tutorial>`, you go through that first.
   InteractiveRobot robot;
-  /* Create a PlanningScene */
   g_planning_scene = new planning_scene::PlanningScene(robot.robotModel());
 
   // Adding geometry to the PlanningScene

--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -88,7 +88,7 @@ Optional: add the previous command to your ``.bashrc``: ::
 Switch to Cyclone DDS
 ^^^^^^^^^^^^^^^^^^^^^
 
-As of Sep 26, 2022, the default ROS2 DDS has an issue. As a workaround, switch to Cyclone. (Note: this makes all nodes started using this RMW incompatible with any other nodes not using Cyclone DDS.) ::
+As of Sep 26, 2022, the default ROS 2 middleware (RMW) implementation has an issue. As a workaround, switch to Cyclone DDS. (Note: this makes all nodes started using this RMW incompatible with any other nodes not using Cyclone DDS.) ::
 
   sudo apt install ros-rolling-rmw-cyclonedds-cpp
   # You may want to add this to ~/.bashrc to source it automatically

--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -88,7 +88,7 @@ Optional: add the previous command to your ``.bashrc``: ::
 Switch to Cyclone DDS
 ^^^^^^^^^^^^^^^^^^^^^
 
-As of Sep 26, 2022, the default ROS2 DDS has an issue. As a workaround, switch to Cyclone. (Note: this makes all nodes started using this RMW incompatible with any other nodes not using Cyclone DDS.)
+As of Sep 26, 2022, the default ROS2 DDS has an issue. As a workaround, switch to Cyclone. (Note: this makes all nodes started using this RMW incompatible with any other nodes not using Cyclone DDS.) ::
 
   sudo apt install ros-rolling-rmw-cyclonedds-cpp
   # You may want to add this to ~/.bashrc to source it automatically


### PR DESCRIPTION
A very small formatting fix.

Before:
![Screenshot from 2022-12-29 09-18-07](https://user-images.githubusercontent.com/11284393/209980448-853215ce-c49a-43ca-9a3e-f80527494812.png)

After:
![Screenshot from 2022-12-29 10-18-12](https://user-images.githubusercontent.com/11284393/209980566-485aa3c2-ddad-40e2-b95c-3fb0776413fd.png)
