### PR TITLE
Dropped moveit_task_constructor/.repos

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -60,7 +60,6 @@ Move into your colcon workspace and pull the MoveIt Task Constructor source: ::
 
     cd ~/ws_moveit/src
     git clone git@github.com:ros-planning/moveit_task_constructor.git -b ros2
-    vcs import < moveit_task_constructor/.repos
 
 3 Trying It Out
 ------------------


### PR DESCRIPTION
There is no `.repos` file in latest [ros2 branch](https://github.com/ros-planning/moveit_task_constructor/tree/ros2).