### PR TITLE
Remove ros2_control from repos file on main

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -23,7 +23,3 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_resources
     version: ros2
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
-    version: 2.19.0


### PR DESCRIPTION
### Description

Here lies a trade-off. In the past, we pinned ros2_control to some version (2.19.0).

First we did it because of the breaking change in ros2_control from Fake to Mock: https://github.com/ros-planning/moveit2_tutorials/commit/215c7711fb568c9492515027c50f06dafa40ae10

Then it got bumped again recently to the "latest version": https://github.com/ros-planning/moveit2_tutorials/commit/502f5e6dca1dab4b42da7df260c140da6de8b668

This was just 4 days ago... yet the latest version of ros2_control on Rolling is not 2.19.0, it is 3.5.0. See [ros index](https://index.ros.org/r/ros2_control/#rolling).

We can keep trying to update this or switch to using ros2_control from the buildfarm's binaries. The second choice is the correct one. The trade-off, though, is that we need to pay attention to breaking changes in ros2_control. We will only be notified of them when the build farm stops working for MoveIt. On the other hand, ros2_control has often been broken on its main branch, which is why we started pinning versions here. 

**Which would you prefer?** 
- Are the tutorials where we want to hide this test for when ros2_control changes? 
- Would it be better to put a test on MoveIt itself? How do we prevent this from going out of date if we pin a tag?
- Are the tutorials about new users experiencing MoveIt, or is it a place for us to catch breaking changes in ros2_control?
- Who updates the tags if we use them? Should we build a tool for this? A CI job?