### PR TITLE
Add changes from #563. Fix Moveit_cpp tutorial

### DIFF
--- a/doc/examples/moveit_cpp/src/moveit_cpp_tutorial.cpp
+++ b/doc/examples/moveit_cpp/src/moveit_cpp_tutorial.cpp
@@ -40,6 +40,8 @@ int main(int argc, char** argv)
   //
   static const std::string PLANNING_GROUP = "panda_arm";
   static const std::string LOGNAME = "moveit_cpp_tutorial";
+  // ros2_controllers
+  static const std::vector<std::string> CONTROLLERS(1, "panda_arm_controller");
 
   /* Otherwise robot with zeros joint_states */
   rclcpp::sleep_for(std::chrono::seconds(1));
@@ -95,7 +97,7 @@ int main(int argc, char** argv)
 
   // Now, we call the PlanningComponents to compute the plan and visualize it.
   // Note that we are just planning
-  auto plan_solution1 = planning_components->plan();
+  const planning_interface::MotionPlanResponse plan_solution1 = planning_components->plan();
 
   // Check if PlanningComponents succeeded in finding the plan
   if (plan_solution1)
@@ -106,11 +108,12 @@ int main(int argc, char** argv)
     visual_tools.publishAxisLabeled(target_pose1.pose, "target_pose");
     visual_tools.publishText(text_pose, "setStartStateToCurrentState", rvt::WHITE, rvt::XLARGE);
     // Visualize the trajectory in Rviz
-    visual_tools.publishTrajectoryLine(plan_solution1.trajectory, joint_model_group_ptr);
+    visual_tools.publishTrajectoryLine(plan_solution1.trajectory_, joint_model_group_ptr);
     visual_tools.trigger();
 
     /* Uncomment if you want to execute the plan */
-    /* planning_components->execute(); // Execute the plan */
+    /* bool blocking = true; */
+    /* moveit_controller_manager::ExecutionStatus result = moveit_cpp_ptr->execute(plan_solution1.trajectory_, blocking, CONTROLLERS); */
   }
 
   // Plan #1 visualization:
@@ -145,16 +148,17 @@ int main(int argc, char** argv)
   if (plan_solution2)
   {
     moveit::core::RobotState robot_state(robot_model_ptr);
-    moveit::core::robotStateMsgToRobotState(plan_solution2.start_state, robot_state);
+    moveit::core::robotStateMsgToRobotState(plan_solution2.start_state_, robot_state);
 
     visual_tools.publishAxisLabeled(robot_state.getGlobalLinkTransform("panda_link8"), "start_pose");
     visual_tools.publishAxisLabeled(target_pose1.pose, "target_pose");
     visual_tools.publishText(text_pose, "moveit::core::RobotState_Start_State", rvt::WHITE, rvt::XLARGE);
-    visual_tools.publishTrajectoryLine(plan_solution2.trajectory, joint_model_group_ptr);
+    visual_tools.publishTrajectoryLine(plan_solution2.trajectory_, joint_model_group_ptr);
     visual_tools.trigger();
 
     /* Uncomment if you want to execute the plan */
-    /* planning_components->execute(); // Execute the plan */
+    /* bool blocking = true; */
+    /* moveit_cpp_ptr->execute(plan_solution2.trajectory_, blocking, CONTROLLERS); */
   }
 
   // Plan #2 visualization:
@@ -189,16 +193,17 @@ int main(int argc, char** argv)
   if (plan_solution3)
   {
     moveit::core::RobotState robot_state(robot_model_ptr);
-    moveit::core::robotStateMsgToRobotState(plan_solution3.start_state, robot_state);
+    moveit::core::robotStateMsgToRobotState(plan_solution3.start_state_, robot_state);
 
     visual_tools.publishAxisLabeled(robot_state.getGlobalLinkTransform("panda_link8"), "start_pose");
     visual_tools.publishAxisLabeled(target_pose2, "target_pose");
     visual_tools.publishText(text_pose, "moveit::core::RobotState_Goal_Pose", rvt::WHITE, rvt::XLARGE);
-    visual_tools.publishTrajectoryLine(plan_solution3.trajectory, joint_model_group_ptr);
+    visual_tools.publishTrajectoryLine(plan_solution3.trajectory_, joint_model_group_ptr);
     visual_tools.trigger();
 
     /* Uncomment if you want to execute the plan */
-    /* planning_components->execute(); // Execute the plan */
+    /* bool blocking = true; */
+    /* moveit_cpp_ptr->execute(plan_solution3.trajectory_, blocking, CONTROLLERS); */
   }
 
   // Plan #3 visualization:
@@ -231,16 +236,17 @@ int main(int argc, char** argv)
   if (plan_solution4)
   {
     moveit::core::RobotState robot_state(robot_model_ptr);
-    moveit::core::robotStateMsgToRobotState(plan_solution4.start_state, robot_state);
+    moveit::core::robotStateMsgToRobotState(plan_solution4.start_state_, robot_state);
 
     visual_tools.publishAxisLabeled(robot_state.getGlobalLinkTransform("panda_link8"), "start_pose");
     visual_tools.publishAxisLabeled(robot_start_state->getGlobalLinkTransform("panda_link8"), "target_pose");
     visual_tools.publishText(text_pose, "Goal_Pose_From_Named_State", rvt::WHITE, rvt::XLARGE);
-    visual_tools.publishTrajectoryLine(plan_solution4.trajectory, joint_model_group_ptr);
+    visual_tools.publishTrajectoryLine(plan_solution4.trajectory_, joint_model_group_ptr);
     visual_tools.trigger();
 
     /* Uncomment if you want to execute the plan */
-    /* planning_components->execute(); // Execute the plan */
+    /* bool blocking = true; */
+    /* moveit_cpp_ptr->execute(plan_solution4.trajectory_, blocking, CONTROLLERS); */
   }
 
   // Plan #4 visualization:
@@ -289,11 +295,12 @@ int main(int argc, char** argv)
   if (plan_solution5)
   {
     visual_tools.publishText(text_pose, "Planning_Around_Collision_Object", rvt::WHITE, rvt::XLARGE);
-    visual_tools.publishTrajectoryLine(plan_solution5.trajectory, joint_model_group_ptr);
+    visual_tools.publishTrajectoryLine(plan_solution5.trajectory_, joint_model_group_ptr);
     visual_tools.trigger();
 
     /* Uncomment if you want to execute the plan */
-    /* planning_components->execute(); // Execute the plan */
+    /* bool blocking = true; */
+    /* moveit_cpp_ptr->execute(plan_solution5.trajectory_, blocking, CONTROLLERS); */
   }
 
   // Plan #5 visualization:


### PR DESCRIPTION
### Description

The struct `MotionPlanResponse` change the name pattern of its members, causing a compilation error when building the file `moveit_cpp_tutorial.cpp`. Error output:

``` log
--- stderr: moveit2_tutorials                                
/root/ws_moveit/src/moveit2_tutorials/doc/examples/moveit_cpp/src/moveit_cpp_tutorial.cpp: In function ‘int main(int, char**)’:
/root/ws_moveit/src/moveit2_tutorials/doc/examples/moveit_cpp/src/moveit_cpp_tutorial.cpp:109:55: error: ‘struct planning_interface::MotionPlanResponse’ has no member named ‘trajectory’; did you mean ‘trajectory_’?
  109 |     visual_tools.publishTrajectoryLine(plan_solution1.trajectory, joint_model_group_ptr);
```

Such changes were addressed in the main branch (PR [#563](https://github.com/ros-planning/moveit2_tutorials/pull/563)). This PR just add those changes to the humble branch.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
