### PR TITLE
Temporarily use fixed version of moveit2 until API breakage is resolved

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -18,7 +18,7 @@ repositories:
   moveit2:
     type: git
     url: https://github.com/ros-planning/moveit2
-    version: main
+    version: bff9600680aa9337680365dc274e4265bb225f7d # TODO(sjahr): Revert to main once https://github.com/ros-planning/moveit2_tutorials/pull/592 is merged
   moveit_resources:
     type: git
     url: https://github.com/ros-planning/moveit_resources


### PR DESCRIPTION
### Description
#592 addresses the latest API breakage on moveit2 main but that PR is blocked by [moveit_task_constructor#426](https://github.com/ros-planning/moveit_task_constructor/pull/426) which cannot be merged since no specific rolling branch exists yet. I'd propose to temporarily depend on the commit on moveit2 main before the API breakage so the tutorials are not broken until the rest is figured out

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
