### PR TITLE
Fix python motion planning tutorial

### DIFF
--- a/doc/examples/motion_planning_python_api/motion_planning_python_api_tutorial.rst
+++ b/doc/examples/motion_planning_python_api/motion_planning_python_api_tutorial.rst
@@ -23,7 +23,7 @@ This tutorial is broken down into the following sections:
 The code for this tutorial can be found :codedir:`here in the moveit2_tutorials GitHub project<examples/motion_planning_python_api>`.
 
 Getting Started
-==================================
+-----------------------------------------------
 To complete this tutorial, you must have set up a workspace that includes MoveIt 2 and its corresponding tutorials.
 An outline on how to set up such a workspace is provided in the :doc:`Getting Started Guide </doc/tutorials/getting_started/getting_started>`, please consult this guide for further information.
 
@@ -32,7 +32,7 @@ Once you have set up your workspace, you can execute the code for this tutorial 
         ros2 launch moveit2_tutorials motion_planning_python_api_tutorial.launch.py
 
 Understanding Planning Parameters
-==================================
+----------------------------------------------------
 MoveIt supports the use of multiple planning libraries out of the box and it is important that we provide settings/parameters for the planners we wish to use.
 
 To accomplish this we specify a yaml configuration file that defines the parameters associated with our ``moveit_py`` node.
@@ -149,47 +149,69 @@ For each of these named pipelines we must provide a configuration that identifie
 These specified parameters will be made available as ``moveit_py`` node parameters and will be leveraged at runtime when performing planning. This is what we will investigate next.
 
 Instantiating moveit_py and planning component
-==================================================
+----------------------------------------------------
 Before we can plan motions we need to instantiate a ``moveit_py`` node and its derived planning component. We will also instantiate a rclpy logger object: ::
 
         rclpy.init()
         logger = rclpy.logging.get_logger("moveit_py.pose_goal")
 
         # instantiate MoveItPy instance and get planning component
-        moveit = MoveItPy(node_name="moveit_py")
-        panda_arm = moveit.get_planning_component("panda_arm")
+        panda = MoveItPy(node_name="moveit_py")
+        panda_arm = panda.get_planning_component("panda_arm")
         logger.info("MoveItPy instance created")
 
-Using the planning component represented by the ``panda_arm`` variable we can begin to perform motion planning.
+Using the planning component represented by the ``panda_arm`` variable we can begin to perform motion planning. We also define a helper function for planning and executing motions: ::
+
+        def plan_and_execute(
+                robot,
+                planning_component,
+                logger,
+                single_plan_parameters=None,
+                multi_plan_parameters=None,
+                ):
+                """A helper function to plan and execute a motion."""
+                # plan to goal
+                logger.info("Planning trajectory")
+                if multi_plan_parameters is not None:
+                        plan_result = planning_component.plan(
+                                multi_plan_parameters=multi_plan_parameters
+                        )
+                elif single_plan_parameters is not None:
+                        plan_result = planning_component.plan(
+                                single_plan_parameters=single_plan_parameters
+                        )
+                else:
+                        plan_result = planning_component.plan()
+
+                # execute the plan
+                if plan_result:
+                        logger.info("Executing plan")
+                        robot_trajectory = plan_result.trajectory
+                        robot.execute(robot_trajectory, blocking=True, controllers=[])
+                else:
+                        logger.error("Planning failed")
 
 Single Pipeline Planning - Default Configurations
-==================================================
+----------------------------------------------------
 We start exploring the ``moveit_py`` motion planning API through executing a single planning pipeline which will plan to a predefined robot configuration (defined in the srdf file): ::
 
         # set plan start state using predefined state
         panda_arm.set_start_state(configuration_name="ready")
 
         # set pose goal using predefined state
-        panda_arm.set_goal(configuration_name="extended")
+        panda_arm.set_goal_state(configuration_name="extended")
 
         # plan to goal
-        logger.info("Planning trajectory")
-        plan_result = panda_arm.plan()
-
-        # execute the plan
-        if plan_result:
-                logger.info("Executing plan")
-                panda_arm.execute()
-
+        plan_and_execute(panda, panda_arm, logger)
 
 Single Pipeline Planning - Robot State
-==================================================
-Next we will plan to a robot state.
-Such a method is quite flexible as we can alter the robot state configuration as we wish (e.g. through setting joint values), here we will just set the robot state to a random configuration for simplicity. We will use the ``set_start_state_to_current_state`` method to set the start state of the robot to its current state and the ``set_goal`` method to set the goal state of the robot.
+----------------------------------------------------
+Next we will plan to a robot state. 
+Such a method is quite flexible as we can alter the robot state configuration as we wish (e.g. through setting joint values), here we will just set the robot state to a random configuration for simplicity. We will use the ``set_start_state_to_current_state`` method to set the start state of the robot to its current state and the ``set_goal_state`` method to set the goal state of the robot. 
 We will then plan to the goal state and execute the plan: ::
 
         # instantiate a RobotState instance using the current robot model
-        robot_model = moveit.get_robot_model()
+        robot_model = panda.get_robot_model()
         robot_state = RobotState(robot_model)
 
         # randomize the robot state
@@ -200,20 +222,13 @@ We will then plan to the goal state and execute the plan: ::
 
         # set goal state to the initialized robot state
         logger.info("Set goal state to the initialized robot state")
-        panda_arm.set_goal(robot_state=robot_state)
+        panda_arm.set_goal_state(robot_state=robot_state)
 
         # plan to goal
-        logger.info("Planning trajectory")
-        plan_result = panda_arm.plan()
-
-        # execute the plan
-        if plan_result:
-                logger.info("Executing plan")
-                panda_arm.execute()
-
+        plan_and_execute(panda, panda_arm, logger)
 
 Single Pipeline Planning - Pose Goal
-==================================================
+----------------------------------------------------
 Another common way to specify a goal state is via a ROS message representing the pose goal.
 Here we demonstrate how to set a pose goal for the end effector of the robot: ::
 
@@ -227,24 +242,14 @@ Here we demonstrate how to set a pose goal for the end effector of the robot: ::
         pose_goal.pose.position.x = 0.28
         pose_goal.pose.position.y = -0.2
         pose_goal.pose.position.z = 0.5
-        pose_goal = {"link_name": "panda_link8", "pose": pose_goal}
-        panda_arm.set_goal(pose_goal=pose_goal)
+        panda_arm.set_goal_state(pose_stamped_msg=pose_goal, pose_link="panda_link8")
 
         # plan to goal
-        logger.info("Planning trajectory")
-        plan_result = panda_arm.plan()
-
-        # execute the plan
-        if plan_result:
-                logger.info("Executing plan")
-                panda_arm.execute()
+        plan_and_execute(panda, panda_arm, logger)
 
 Single Pipeline Planning - Custom Constraints
-==================================================
+----------------------------------------------------
 You can also control the output of motion planning via custom constraints. Here we demonstrate planning to a configuration that satisfies a set of joint constraints: ::
-
-        # set plan start state to current state
-        panda_arm.set_start_state_to_current_state()
 
         # set plan start state to current state
         panda_arm.set_start_state_to_current_state()
@@ -262,40 +267,36 @@ You can also control the output of motion planning via custom constraints. Here 
         robot_state.joint_positions = joint_values
         joint_constraint = construct_joint_constraint(
                 robot_state=robot_state,
-                joint_model_group=moveit.get_robot_model().get_joint_model_group("panda_arm"),
+                joint_model_group=panda.get_robot_model().get_joint_model_group("panda_arm"),
         )
-        panda_arm.set_goal(motion_plan_constraints=[joint_constraint])
+        panda_arm.set_goal_state(motion_plan_constraints=[joint_constraint])
 
         # plan to goal
-        logger.info("Planning trajectory")
-        plan_result = panda_arm.plan()
-
-        # execute the plan
-        if plan_result:
-                logger.info("Executing plan")
-                panda_arm.execute()
+        plan_and_execute(panda, panda_arm, logger)
 
 Multi Pipeline Planning
-===========================
+----------------------------------------------------
 A recent addition to ``moveit_cpp`` and ``moveit_py`` is the ability to execute multiple planning pipelines in parallel and select the resulting motion plan amongst all generated motion plans that best satisfies your task requirements.
 In previous sections, we defined a set of planning pipelines.
-Here we will see how to plan in parallel with several of these pipelines : ::
+Here we will see how to plan in parallel with several of these pipelines: ::
 
         # set plan start state to current state
         panda_arm.set_start_state_to_current_state()
 
         # set pose goal with PoseStamped message
-        panda_arm.set_goal(configuration_name="ready")
+        panda_arm.set_goal_state(configuration_name="ready")
 
         # initialise multi-pipeline plan request parameters
         multi_pipeline_plan_request_params = MultiPipelinePlanRequestParameters(
-                moveit, ["ompl_rrtc", "pilz_lin", "chomp", "ompl_rrt_star"]
+                panda, ["ompl_rrtc", "pilz_lin", "chomp", "ompl_rrt_star"]
         )
 
         # plan to goal
-        logger.info("Planning trajectory")
-        plan_result = panda_arm.plan(
-                multi_plan_parameters=multi_pipeline_plan_request_params
+        plan_and_execute(
+                panda,
+                panda_arm,
+                logger,
+                multi_plan_parameters=multi_pipeline_plan_request_params,
         )
 
         # execute the plan
@@ -304,7 +305,7 @@ Here we will see how to plan in parallel with several of these pipelines : ::
                 panda_arm.execute()
 
 Using a Planning Scene
-===========================
+----------------------------------------------------
 The code for this section requires you to run a different Python file, which you can specify as follows ::
 
         ros2 launch moveit2_tutorials motion_planning_python_api_tutorial.launch.py example_file:=motion_planning_python_api_planning_scene.py

--- a/doc/examples/motion_planning_python_api/motion_planning_python_api_tutorial.rst
+++ b/doc/examples/motion_planning_python_api/motion_planning_python_api_tutorial.rst
@@ -206,8 +206,8 @@ We start exploring the ``moveit_py`` motion planning API through executing a sin
 
 Single Pipeline Planning - Robot State
 ----------------------------------------------------
-Next we will plan to a robot state. 
-Such a method is quite flexible as we can alter the robot state configuration as we wish (e.g. through setting joint values), here we will just set the robot state to a random configuration for simplicity. We will use the ``set_start_state_to_current_state`` method to set the start state of the robot to its current state and the ``set_goal_state`` method to set the goal state of the robot. 
+Next we will plan to a robot state.
+Such a method is quite flexible as we can alter the robot state configuration as we wish (e.g. through setting joint values), here we will just set the robot state to a random configuration for simplicity. We will use the ``set_start_state_to_current_state`` method to set the start state of the robot to its current state and the ``set_goal_state`` method to set the goal state of the robot.
 We will then plan to the goal state and execute the plan: ::
 
         # instantiate a RobotState instance using the current robot model

--- a/doc/examples/motion_planning_python_api/scripts/motion_planning_python_api_tutorial.py
+++ b/doc/examples/motion_planning_python_api/scripts/motion_planning_python_api_tutorial.py
@@ -125,9 +125,6 @@ def main():
     # set plan start state to current state
     panda_arm.set_start_state_to_current_state()
 
-    # set plan start state to current state
-    panda_arm.set_start_state_to_current_state()
-
     # set constraints message
     from moveit.core.kinematic_constraints import construct_joint_constraint
 


### PR DESCRIPTION
### Description

There are issues with the headings in the tutorial Markdown, they were being given the same precedence as the tutorial title which this fixes.

Somehow the markdown file had inconsistencies with the tutorial scripts. This is likely due to a force push that overwrote changes, I also ensure that the Markdown file aligns with the scripts.

Closes https://github.com/ros-planning/moveit2_tutorials/issues/643