### PR TITLE
Update Quickstart in RViz Tutorial Documentation and RViz Config argument name

### DIFF
--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -20,13 +20,6 @@ def generate_launch_description():
             description="RViz configuration file",
         )
     )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "rviz_tutorial",
-            default_value="False",
-            description="Tutorial flag for empty Rviz config",
-        )
-    )
 
     return LaunchDescription(
         declared_arguments + [OpaqueFunction(function=launch_setup)]
@@ -56,30 +49,12 @@ def launch_setup(context, *args, **kwargs):
         parameters=[moveit_config.to_dict()],
     )
 
-    # RViz
-    tutorial_mode = LaunchConfiguration("rviz_tutorial")
     rviz_config_file = LaunchConfiguration("rviz_config")
-    rviz_base = os.path.join(get_package_share_directory("moveit2_tutorials"), "launch")
-    rviz_config = PathJoinSubstitution([rviz_base, rviz_config_file])
-    rviz_config_empty = PathJoinSubstitution(
-        [rviz_base, "panda_moveit_config_demo_empty.rviz"]
+    rviz_config = PathJoinSubstitution(
+        [FindPackageShare("moveit2_tutorials"), "launch", rviz_config_file]
     )
 
-    rviz_node_tutorial = Node(
-        package="rviz2",
-        executable="rviz2",
-        name="rviz2",
-        output="log",
-        arguments=["-d", rviz_config_empty],
-        parameters=[
-            moveit_config.robot_description,
-            moveit_config.robot_description_semantic,
-            moveit_config.robot_description_kinematics,
-            moveit_config.planning_pipelines,
-            moveit_config.joint_limits,
-        ],
-        condition=IfCondition(tutorial_mode),
-    )
+    # RViz
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
@@ -93,7 +68,6 @@ def launch_setup(context, *args, **kwargs):
             moveit_config.planning_pipelines,
             moveit_config.joint_limits,
         ],
-        condition=UnlessCondition(tutorial_mode),
     )
 
     # Static TF
@@ -151,7 +125,6 @@ def launch_setup(context, *args, **kwargs):
         arguments=["panda_hand_controller", "-c", "/controller_manager"],
     )
     nodes_to_start = [
-        rviz_node_tutorial,
         rviz_node,
         static_tf,
         robot_state_publisher,

--- a/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -14,7 +14,7 @@ Step 1: Launch the Demo and Configure the Plugin
 
 * Launch the demo: ::
 
-   ros2 launch moveit2_tutorials demo.launch.py
+   ros2 launch moveit2_tutorials demo.launch.py rviz_config:=panda_moveit_config_demo_empty.rviz
 
 * If you are doing this for the first time, you should see an empty world in RViz and will have to add the Motion Planning Plugin:
 


### PR DESCRIPTION
### Description

~~Fixes the rviz_tutorial flag in the "MoveIt Quickstart in Rviz" tutorial, as referenced in [Issue 586](https://github.com/ros-planning/moveit2_tutorials/issues/586). Added to declared launch arguments as well, since not setting it on the command line caused an error.~~
Original PR superseded by https://github.com/ros-planning/moveit2_tutorials/pull/635 since problem is mostly fixed in `main`. Edited to include small change to documentation and naming convention going forward; feel free to close if too minor a change.


### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
