### PR TITLE
Clean up CMakeLists for MTC tutorial

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/CMakeLists.txt
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/CMakeLists.txt
@@ -1,9 +1,7 @@
 add_executable(mtc_tutorial src/mtc_node.cpp)
-target_compile_options(mtc_tutorial PUBLIC -g -O0)
 ament_target_dependencies(mtc_tutorial ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_executable(minimal_mtc_tutorial src/minimal.cpp)
-target_compile_options(minimal_mtc_tutorial PUBLIC -g -O0)
 ament_target_dependencies(minimal_mtc_tutorial ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 install(TARGETS mtc_tutorial minimal_mtc_tutorial


### PR DESCRIPTION
These lines were likely just added for debugging purposes.
