### PR TITLE
Fix launch warnings for MTC tutorial

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/launch/mtc_demo.launch.py
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/launch/mtc_demo.launch.py
@@ -12,6 +12,9 @@ def generate_launch_description():
         MoveItConfigsBuilder("moveit_resources_panda")
         .robot_description(file_path="config/panda.urdf.xacro")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
+        .planning_pipelines(
+            pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"]
+        )
         .to_moveit_configs()
     )
 
@@ -44,6 +47,7 @@ def generate_launch_description():
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
+            moveit_config.robot_description_kinematics,
         ],
     )
 


### PR DESCRIPTION
### Description

This PR fixes the following warnings when launching the MTC demo:
```
[ERROR] [1678136118.485318346] [moveit.ros_planning_interface.moveit_cpp]: Failed to initialize planning pipeline 'trajopt'.
```
```
[ERROR] [1678136118.493854644] [moveit.ros_planning_interface.moveit_cpp]: Failed to initialize planning pipeline 'lerp'.
```
These two errors are caused by MoveIt Configs Utils trying to load all files that match the `*_planning.yaml` files available in MoveIt Resources (see #521). The fix for this is to specify the desired planning pipelines (OMPL, CHOMP, and Pilz), similarly to how it is done in the [Quickstart launch](https://github.com/ros-planning/moveit2_tutorials/blob/main/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py).

```
[rviz2-1] [WARN] [1678136119.251836273] [moveit_ros.robot_model_loader]: No kinematics plugins defined. Fill and load kinematics.yaml!
```
This is caused by not providing RViz with `robot_description_kinematics`, which this PR intends to fix.