### PR TITLE
Pr fix humble quickstart tutorial launch

### DIFF
--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -49,43 +49,23 @@ def launch_setup(context, *args, **kwargs):
         parameters=[moveit_config.to_dict()],
     )
 
-    rviz_base = LaunchConfiguration("rviz_config")
-    rviz_config = PathJoinSubstitution(
-        [FindPackageShare("moveit2_tutorials"), "launch", rviz_base]
-    )
+    rviz_base = os.path.join(get_package_share_directory("moveit2_tutorials"), "launch")
+    rviz_config = os.path.join(rviz_base, "panda_moveit_config_demo.rviz")
 
     # RViz
-    tutorial_mode = LaunchConfiguration("rviz_tutorial")
-    rviz_base = os.path.join(get_package_share_directory("moveit2_tutorials"), "launch")
-    rviz_full_config = os.path.join(rviz_base, "panda_moveit_config_demo.rviz")
-    rviz_empty_config = os.path.join(rviz_base, "panda_moveit_config_demo_empty.rviz")
-    rviz_node_tutorial = Node(
-        package="rviz2",
-        executable="rviz2",
-        name="rviz2",
-        output="log",
-        arguments=["-d", rviz_empty_config],
-        parameters=[
-            moveit_config.robot_description,
-            moveit_config.robot_description_semantic,
-            moveit_config.robot_description_kinematics,
-            moveit_config.planning_pipelines,
-        ],
-        condition=IfCondition(tutorial_mode),
-    )
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
         name="rviz2",
         output="log",
-        arguments=["-d", rviz_full_config],
+        arguments=["-d", rviz_config],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.robot_description_kinematics,
             moveit_config.planning_pipelines,
+            moveit_config.joint_limits,
         ],
-        condition=UnlessCondition(tutorial_mode),
     )
 
     # Static TF

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -49,8 +49,10 @@ def launch_setup(context, *args, **kwargs):
         parameters=[moveit_config.to_dict()],
     )
 
-    rviz_base = os.path.join(get_package_share_directory("moveit2_tutorials"), "launch")
-    rviz_config = os.path.join(rviz_base, "panda_moveit_config_demo.rviz")
+    rviz_base = LaunchConfiguration("rviz_config")
+    rviz_config = PathJoinSubstitution(
+        [FindPackageShare("moveit2_tutorials"), "launch", rviz_base]
+    )
 
     # RViz
     rviz_node = Node(

--- a/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -14,7 +14,7 @@ Step 1: Launch the Demo and Configure the Plugin
 
 * Launch the demo: ::
 
-   ros2 launch moveit2_tutorials demo.launch.py rviz_tutorial:=true
+   ros2 launch moveit2_tutorials demo.launch.py
 
 * If you are doing this for the first time, you should see an empty world in RViz and will have to add the Motion Planning Plugin:
 

--- a/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -14,7 +14,7 @@ Step 1: Launch the Demo and Configure the Plugin
 
 * Launch the demo: ::
 
-   ros2 launch moveit2_tutorials demo.launch.py
+   ros2 launch moveit2_tutorials demo.launch.py rviz_config:=panda_moveit_config_demo_empty.rviz
 
 * If you are doing this for the first time, you should see an empty world in RViz and will have to add the Motion Planning Plugin:
 


### PR DESCRIPTION
### Description
Resolves [Issue 568](https://github.com/ros-planning/moveit2_tutorials/issues/586). This PR just finishes removing the rviz_tutorial launch argument  in `humble`, which was removed in `main`, and partially removed in `humble` following backports. This also updates the documentation to specify the correct argument to use in accordance with the [Quickstart In RViz Tutorial](https://moveit.picknik.ai/humble/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html) so that the initial scene is empty. 

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
