### PR TITLE
Isaac tutorial: pass through ROS_DOMAIN_ID

### DIFF
--- a/doc/how_to_guides/isaac_panda/docker-compose.yaml
+++ b/doc/how_to_guides/isaac_panda/docker-compose.yaml
@@ -26,7 +26,8 @@ services:
     ipc: host
     privileged: true
     environment:
-      - ROS_DOMAIN_ID
+      # Default the ROS_DOMAIN_ID to zero if not set on the host
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
       # Allows graphical programs in the container
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1

--- a/doc/how_to_guides/isaac_panda/launch/isaac_moveit.py
+++ b/doc/how_to_guides/isaac_panda/launch/isaac_moveit.py
@@ -121,7 +121,7 @@ try:
                 ),
             ],
             og.Controller.Keys.SET_VALUES: [
-            	 ("Context.inputs:useDomainIDEnvVar", 1),
+                ("Context.inputs:useDomainIDEnvVar", 1),
                 # Setting the /Franka target prim to Articulation Controller node
                 ("ArticulationController.inputs:usePath", True),
                 ("ArticulationController.inputs:robotPath", FRANKA_STAGE_PATH),

--- a/doc/how_to_guides/isaac_panda/launch/isaac_moveit.py
+++ b/doc/how_to_guides/isaac_panda/launch/isaac_moveit.py
@@ -121,6 +121,7 @@ try:
                 ),
             ],
             og.Controller.Keys.SET_VALUES: [
+            	 ("Context.inputs:useDomainIDEnvVar", 1),
                 # Setting the /Franka target prim to Articulation Controller node
                 ("ArticulationController.inputs:usePath", True),
                 ("ArticulationController.inputs:robotPath", FRANKA_STAGE_PATH),


### PR DESCRIPTION
### Description

This PR fixes passing the users ROS_DOMAIN_ID into the docker container and also sets up Isaac to use the same value.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
