### PR TITLE
Update Dockerfile on the humble branch to use ROS humble

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.3
 
-ARG ROS_DISTRO=rolling
+ARG ROS_DISTRO=humble
 
 ######################### Tutorial Image  #################################################
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [humble, rolling]
+        ROS_DISTRO: [humble]
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
### Description

The backport in https://github.com/ros-planning/moveit2_tutorials/commit/e292e4da088420c41269e5301be132a1ca9661ca set the `ROS_DISTRO` to `rolling` for the `humble` branch, which would probably cause issues for users who are trying to go through the MoveIt2 tutorials with MoveIt2 humble. This PR sets the `ROS_DISTRO` to `humble` in the Dockerfile so that if users decide to use the Docker setup for the humble tutorials, `ROS_DISTRO` matches the MoveIt2 version.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
