### PR TITLE
Rename variable kinematic_state to robot_state

### DIFF
--- a/doc/examples/kinematics/src/ros_api_tutorial.cpp
+++ b/doc/examples/kinematics/src/ros_api_tutorial.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
   /* Filling in a seed state */
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
   const moveit::core::RobotModelPtr& kinematic_model = robot_model_loader.getModel();
-  moveit::core::RobotStatePtr kinematic_state(new moveit::core::RobotState(kinematic_model));
+  moveit::core::RobotStatePtr robot_state(new moveit::core::RobotState(kinematic_model));
   const moveit::core::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup("panda_arm");
 
   /* Get the names of the joints in the panda_arm*/
@@ -98,9 +98,8 @@ int main(int argc, char** argv)
 
   /* Get the joint values and put them into the message, this is where you could put in your own set of values as
    * well.*/
-  kinematic_state->setToRandomPositions(joint_model_group);
-  kinematic_state->copyJointGroupPositions(joint_model_group,
-                                           service_request.ik_request.robot_state.joint_state.position);
+  robot_state->setToRandomPositions(joint_model_group);
+  robot_state->copyJointGroupPositions(joint_model_group, service_request.ik_request.robot_state.joint_state.position);
 
   /* Call the service again*/
   service_client.call(service_request, service_response);
@@ -120,8 +119,8 @@ int main(int argc, char** argv)
 
   /* Visualize the result*/
   moveit_msgs::DisplayRobotState msg;
-  kinematic_state->setVariableValues(service_response.solution.joint_state);
-  moveit::core::robotStateToRobotStateMsg(*kinematic_state, msg.state);
+  robot_state->setVariableValues(service_response.solution.joint_state);
+  moveit::core::robotStateToRobotStateMsg(*robot_state, msg.state);
   robot_state_publisher.publish(msg);
 
   // Sleep to let the message go through

--- a/doc/examples/planning_scene/src/planning_scene_tutorial.cpp
+++ b/doc/examples/planning_scene/src/planning_scene_tutorial.cpp
@@ -13,9 +13,9 @@
 // setStateFeasibilityPredicate function. Here's a simple example of a
 // user-defined callback that checks whether the "panda_joint1" of
 // the Panda robot is at a positive or negative angle:
-bool stateFeasibilityTestExample(const moveit::core::RobotState& kinematic_state, bool /*verbose*/)
+bool stateFeasibilityTestExample(const moveit::core::RobotState& robot_state, bool /*verbose*/)
 {
-  const double* joint_values = kinematic_state.getJointPositions("panda_joint1");
+  const double* joint_values = robot_state.getJointPositions("panda_joint1");
   return (joint_values[0] > 0.0);
 }
 // END_SUB_TUTORIAL

--- a/doc/examples/state_display/src/state_display_tutorial.cpp
+++ b/doc/examples/state_display/src/state_display_tutorial.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
   const moveit::core::RobotModelPtr& kinematic_model = robot_model_loader.getModel();
 
   /* Create a kinematic state - this represents the configuration for the robot represented by kinematic_model */
-  moveit::core::RobotStatePtr kinematic_state(new moveit::core::RobotState(kinematic_model));
+  moveit::core::RobotStatePtr robot_state(new moveit::core::RobotState(kinematic_model));
 
   /* Get the configuration for the joints in the right arm of the Panda*/
   const moveit::core::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup("panda_arm");
@@ -79,11 +79,11 @@ int main(int argc, char** argv)
 
   for (int cnt = 0; cnt < 5 && ros::ok(); cnt++)
   {
-    kinematic_state->setToRandomPositions(joint_model_group);
+    robot_state->setToRandomPositions(joint_model_group);
 
-    /* get a robot state message describing the pose in kinematic_state */
+    /* get a robot state message describing the pose in robot_state */
     moveit_msgs::DisplayRobotState msg;
-    moveit::core::robotStateToRobotStateMsg(*kinematic_state, msg.state);
+    moveit::core::robotStateToRobotStateMsg(*robot_state, msg.state);
 
     /* send the message to the RobotState display */
     robot_state_publisher.publish(msg);
@@ -96,9 +96,9 @@ int main(int argc, char** argv)
   /* POSITION END EFFECTOR AT SPECIFIC LOCATIONS */
 
   /* Find the default pose for the end effector */
-  kinematic_state->setToDefaultValues();
+  robot_state->setToDefaultValues();
 
-  const Eigen::Isometry3d end_effector_default_pose = kinematic_state->getGlobalLinkTransform("r_wrist_roll_link");
+  const Eigen::Isometry3d end_effector_default_pose = robot_state->getGlobalLinkTransform("r_wrist_roll_link");
 
   const double PI = boost::math::constants::pi<double>();
   const double RADIUS = 0.1;
@@ -112,16 +112,16 @@ int main(int argc, char** argv)
     ROS_INFO_STREAM("End effector position:\n" << end_effector_pose.translation());
 
     /* use IK to get joint angles satisfyuing the calculated position */
-    bool found_ik = kinematic_state->setFromIK(joint_model_group, end_effector_pose, 0.1);
+    bool found_ik = robot_state->setFromIK(joint_model_group, end_effector_pose, 0.1);
     if (!found_ik)
     {
       ROS_INFO_STREAM("Could not solve IK for pose\n" << end_effector_pose.translation());
       continue;
     }
 
-    /* get a robot state message describing the pose in kinematic_state */
+    /* get a robot state message describing the pose in robot_state */
     moveit_msgs::DisplayRobotState msg;
-    moveit::core::robotStateToRobotStateMsg(*kinematic_state, msg.state);
+    moveit::core::robotStateToRobotStateMsg(*robot_state, msg.state);
 
     /* send the message to the RobotState display */
     robot_state_publisher.publish(msg);


### PR DESCRIPTION
### Description

Minor variable name cleanup to make the naming more consistent.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
