### PR TITLE
Prevent overriding of Python API artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,9 +134,11 @@ jobs:
 
     - name: Create CNAME file
       run: echo "moveit.picknik.ai" > build/html/CNAME
-
+     
     - name: Build multiversion
-      run: make multiversion
+      run: |
+        rm doc/api/python_api/api.rst  # prevent overriding of artifact version
+        make multiversion
 
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,7 +134,7 @@ jobs:
 
     - name: Create CNAME file
       run: echo "moveit.picknik.ai" > build/html/CNAME
-     
+
     - name: Build multiversion
       run: |
         rm doc/api/python_api/api.rst  # prevent overriding of artifact version


### PR DESCRIPTION
The removed api.rst would fail to build with the multiversion target since the Python libs are not importable. The corresponding api.html is provided with the copied build artifact already.