### PR TITLE
Remove deprecated call to moveit_cpp_->execute()

### DIFF
--- a/doc/how_to_guides/parallel_planning/src/parallel_planning_main.cpp
+++ b/doc/how_to_guides/parallel_planning/src/parallel_planning_main.cpp
@@ -243,7 +243,7 @@ public:
     }
 
     // Execute the trajectory and block until it's finished
-    moveit_cpp_->execute(plan_solution.trajectory, true /* blocking*/, CONTROLLERS);
+    moveit_cpp_->execute(plan_solution.trajectory, CONTROLLERS);
 
     // Start the next plan
     visual_tools_.prompt("Press 'next' in the RvizVisualToolsGui window to continue the demo");


### PR DESCRIPTION
### Description

When building, I get this output from the parallel planning tutorial:

```--- stderr: moveit2_tutorials                                       
/workspaces/ros2-rolling-ws/src/moveit2_tutorials/doc/how_to_guides/parallel_planning/src/parallel_planning_main.cpp: In member function ‘void parallel_planning_example::Demo::planAndPrint()’:
/workspaces/ros2-rolling-ws/src/moveit2_tutorials/doc/how_to_guides/parallel_planning/src/parallel_planning_main.cpp:246:25: warning: ‘moveit_controller_manager::ExecutionStatus moveit_cpp::MoveItCpp::execute(const RobotTrajectoryPtr&, bool, const std::vector<std::__cxx11::basic_string<char> >&)’ is deprecated: MoveItCpp::execute() no longer requires a blocking parameter [-Wdeprecated-declarations]
  246 |     moveit_cpp_->execute(plan_solution.trajectory, true /* blocking*/, CONTROLLERS);
      |     ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /workspaces/ros2-rolling-ws/src/moveit2_tutorials/doc/how_to_guides/parallel_planning/src/parallel_planning_main.cpp:4:
/workspaces/ros2-rolling-ws/src/moveit2/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h:174:3: note: declared here
  174 |   execute(const robot_trajectory::RobotTrajectoryPtr& robot_trajectory, bool blocking,
      |   ^~~~~~~
```
This functionality has been marked deprecated in https://github.com/ros-planning/moveit2/pull/1984