### PR TITLE
Add moveit_msgs to repos file

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -23,3 +23,7 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_resources
     version: ros2
+  moveit_msgs:
+    type: git:
+    url: https://github.com/ros-planning/moveit_msgs
+    version: ros2


### PR DESCRIPTION
### Description

moveit now depends on this change: https://github.com/ros-planning/moveit_msgs/commit/e97a788e80ef2789ded11b3b9b54d0f4b164cc08

cutting a release for moveit_msgs but in the mean time fixing the repos file so it is included 