### PR TITLE
Bulleted list of ros instasll instructions

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -11,9 +11,10 @@ MoveIt 2 currently supports multiple versions of ROS.
 Install whichever version you prefer.
 We primarily support ROS installed Ubuntu 22.04 but other methods and platforms may work with small changes to the instructions listed below.
 If you are just getting started we would recommend you use the latest stable version of ROS (Iron) on Ubuntu 22.04 for the most seamless experience.
-- `Rolling Ridley <https://docs.ros.org/en/rolling/Installation.html>`_ - Rolling Development Release
-- `Irin Irwini <https://docs.ros.org/en/iron/Installation.html>`_ - Latest Stable Release - May 2023
-- `Humble Haskbill <https://docs.ros.org/en/humble/Installation.html>`_ - LTS Release - May 2022
+
+* `Rolling Ridley <https://docs.ros.org/en/rolling/Installation.html>`_ - Rolling Development Release
+* `Irin Irwini <https://docs.ros.org/en/iron/Installation.html>`_ - Latest Stable Release - May 2023
+* `Humble Haskbill <https://docs.ros.org/en/humble/Installation.html>`_ - LTS Release - May 2022
 
 It is easy to miss steps when going through the ROS 2 installation tutorial. If you run into errors in the next few steps, a good place to start is to go back and make sure you have installed ROS 2 correctly.  One that users commonly forget is to source the ROS 2 install itself. Note to source the version of ROS you installed.  ::
 


### PR DESCRIPTION
### Description

This fixes the formatting of the list of ROS releases you can install before setting up moveit.

New:
![image](https://github.com/ros-planning/moveit2_tutorials/assets/2490389/645c15f1-38be-497a-87a8-b6e71079875c)

Old:
![image](https://github.com/ros-planning/moveit2_tutorials/assets/2490389/1cdcdc8a-4e72-4d4c-91d1-0b51080d3df1)
