### PR TITLE
Move Isaac Tutorial link in how_to_guides

### DIFF
--- a/doc/how_to_guides/how_to_guides.rst
+++ b/doc/how_to_guides/how_to_guides.rst
@@ -19,6 +19,7 @@ Configuring and Using MoveIt
    parallel_planning/parallel_planning_tutorial
    controller_teleoperation/controller_teleoperation
    persistent_scenes_and_states/persistent_scenes_and_states
+   isaac_panda/isaac_panda_tutorial
 
 Developing and Documenting MoveIt
 ---------------------------------
@@ -29,5 +30,4 @@ Developing and Documenting MoveIt
    how_to_guide
    how_to_generate_api_doxygen_locally
    how_to_setup_docker_containers_in_ubuntu
-   how_to_write_doxygen
-   isaac_panda/isaac_panda_tutorial
+   how_to_write_doxygen   


### PR DESCRIPTION
### Description

This PR just moves the Isaac tutorial link in the `how_to_guides.rst` to be under the correct section.
