### PR TITLE
Default ROS_DOMAIN_ID if not set for Isaac tutorial

### DIFF
--- a/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.rst
+++ b/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.rst
@@ -2,7 +2,7 @@ How To Command Simulated Isaac Robot
 ====================================
 
 This tutorial requires a machine with ``Isaac Sim 2022.2.0`` or ``Isaac Sim 2022.2.1`` installed.
-For Isaac Sim requirements and installation please see the `Omniverse documentation <https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/overview.html>`_.
+For Isaac Sim requirements and installation please see the `Omniverse documentation <https://docs.omniverse.nvidia.com/isaacsim/latest/index.html>`_.
 
 This tutorial has the following assumptions on system configuration:
 
@@ -56,19 +56,19 @@ updated to load the ``TopicBasedSystem`` plugin when the flag ``ros2_control_har
     </xacro:if>
 
 In this tutorial we have included a Python script that loads a Panda robot
-and builds an `OmniGraph <https://docs.omniverse.nvidia.com/prod_extensions/prod_extensions/ext_omnigraph.html>`_
+and builds an `OmniGraph <https://docs.omniverse.nvidia.com/isaacsim/latest/tutorial_gui_omnigraph.html>`_
 to publish and subscribe to the ROS topics used to control the robot.
 The OmniGraph also contains nodes to publish RGB and Depth images from the camera mounted on the hand of the Panda.
 The RGB image is published to the topic ``/rgb``, the camera info to ``/camera_info``, and the depth image to ``/depth``.
 The frame ID of the camera frame is ``/sim_camera``.
 To learn about configuring your Isaac Sim robot to communicate with ROS 2 please see the
-`Joint Control tutorial <https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/tutorial_ros2_manipulation.html>`_
+`Joint Control tutorial <https://docs.omniverse.nvidia.com/isaacsim/latest/tutorial_ros2_manipulation.html>`_
 on Omniverse.
 
 Computer Setup
 --------------
 
-1. Install `Isaac Sim <https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/install_workstation.html>`_.
+1. Install `Isaac Sim <https://docs.omniverse.nvidia.com/isaacsim/latest/install_workstation.html>`_.
 
 2. Perform a shallow clone of the MoveIt2 Tutorials repo.
 

--- a/doc/how_to_guides/isaac_panda/launch/isaac_moveit.py
+++ b/doc/how_to_guides/isaac_panda/launch/isaac_moveit.py
@@ -113,6 +113,16 @@ prims.create_prim(
 
 simulation_app.update()
 
+try:
+    ros_domain_id = int(os.environ["ROS_DOMAIN_ID"])
+    print("Using ROS_DOMAIN_ID: ", ros_domain_id)
+except ValueError:
+    print("Invalid ROS_DOMAIN_ID integer value. Setting value to 0")
+    ros_domain_id = 0
+except KeyError:
+    print("ROS_DOMAIN_ID environment variable is not set. Setting value to 0")
+    ros_domain_id = 0
+
 # Creating a action graph with ROS component nodes
 try:
     og.Controller.edit(
@@ -203,7 +213,7 @@ try:
                 ),
             ],
             og.Controller.Keys.SET_VALUES: [
-                ("Context.inputs:domain_id", int(os.environ["ROS_DOMAIN_ID"])),
+                ("Context.inputs:domain_id", ros_domain_id),
                 # Setting the /Franka target prim to Articulation Controller node
                 ("ArticulationController.inputs:usePath", True),
                 ("ArticulationController.inputs:robotPath", FRANKA_STAGE_PATH),


### PR DESCRIPTION
### Description

Fixes #706. 

This PR adds a check to the Isaac python launch script to make sure a valid `ROS_DOMAIN_ID` is set and if not defaults to a value of 0.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
