### PR TITLE
Use ros2 branch of moveit_task_constructor instead of humble

### DIFF
--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -6,7 +6,7 @@ repositories:
   moveit_task_constructor:
     type: git
     url: https://github.com/ros-planning/moveit_task_constructor.git
-    version: humble
+    version: ros2
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -14,7 +14,7 @@ repositories:
   moveit_task_constructor:
     type: git
     url: https://github.com/ros-planning/moveit_task_constructor.git
-    version: humble
+    version: ros2
   moveit_visual_tools:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools


### PR DESCRIPTION
### Description

The humble branch has been removed.
See https://github.com/ros-planning/moveit_task_constructor/issues/480