### PR TITLE
Fix place pose generation IK frame in MTC Tutorial

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -806,7 +806,10 @@ The next stages will be added to the serial container rather than the task.
         place->properties().configureInitFrom(mtc::Stage::PARENT,
                                               { "eef", "group", "ik_frame" });
 
-This next stage generates the poses used to place the object and compute the inverse kinematics for those poses - it is somewhat similar to the ``generate grasp pose`` stage from the pick serial container. We start by creating a stage to generate the poses and inheriting the task properties. We specify the pose where we want to place the object with a ``PoseStamped`` message from ``geometry_msgs`` - in this case, we choose ``y = 0.5``. We then pass the target pose to the stage with ``setPose``.
+This next stage generates the poses used to place the object and compute the inverse kinematics for those poses - it is somewhat similar to the ``generate grasp pose`` stage from the pick serial container.
+We start by creating a stage to generate the poses and inheriting the task properties.
+We specify the pose where we want to place the object with a ``PoseStamped`` message from ``geometry_msgs`` - in this case, we choose ``y = 0.5`` in the ``"object"`` frame.
+We then pass the target pose to the stage with ``setPose``.
 Next, we use ``setMonitoredStage`` and pass it the pointer to the ``attach_object`` stage from earlier.
 This allows the stage to know how the object is attached.
 We then create a ``ComputeIK`` stage and pass it our ``GeneratePlacePose`` stage - the rest follows the same logic as above with the pick stages.
@@ -831,7 +834,7 @@ We then create a ``ComputeIK`` stage and pass it our ``GeneratePlacePose`` stage
               std::make_unique<mtc::stages::ComputeIK>("place pose IK", std::move(stage));
           wrapper->setMaxIKSolutions(2);
           wrapper->setMinSolutionDistance(1.0);
-          wrapper->setIKFrame(hand_frame);
+          wrapper->setIKFrame("object");
           wrapper->properties().configureInitFrom(mtc::Stage::PARENT, { "eef", "group" });
           wrapper->properties().configureInitFrom(mtc::Stage::INTERFACE, { "target_pose" });
           place->insert(std::move(wrapper));

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cpp
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cpp
@@ -297,7 +297,7 @@ mtc::Task MTCTaskNode::createTask()
       // clang-format on
       wrapper->setMaxIKSolutions(2);
       wrapper->setMinSolutionDistance(1.0);
-      wrapper->setIKFrame(hand_frame);
+      wrapper->setIKFrame("object");
       wrapper->properties().configureInitFrom(mtc::Stage::PARENT, { "eef", "group" });
       wrapper->properties().configureInitFrom(mtc::Stage::INTERFACE, { "target_pose" });
       place->insert(std::move(wrapper));


### PR DESCRIPTION
Per the discussion in https://github.com/ros-planning/moveit2_tutorials/issues/723, this PR fixes the IK frame in the MTC tutorial's place pose generation so that the object is not incorrectly rotated by sampling placements in the end effector frame rather than the object frame.