### PR TITLE
Fix bad file copy in Dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -32,7 +32,7 @@ RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
 
 # Remove the hello_world tutorial cpp file and replace it with the planning_around_objects file
 RUN rm src/hello_moveit/src/hello_moveit.cpp
-COPY ./doc/tutorials/planning_around_objects/hello_moveit.cpp src/hello_moveit/src/hello_moveit.cpp
+COPY ./doc/tutorials/planning_around_objects/hello_moveit_kinova.cpp src/hello_moveit/src/hello_moveit.cpp
 
 ######################### Pick and Place (MTC) Image  #########################################
 


### PR DESCRIPTION
Since moving to the Kinova, the `hello_world.cpp` file was broken out into `hello_world_panda.cpp` and `hello_world_kinova.cpp` files. This was not reflected in the Dockerfile, so this PR fixes that.

Closes https://github.com/ros-planning/moveit2_tutorials/issues/737
