### PR TITLE
Fix failure in bringup test

### DIFF
--- a/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
+++ b/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
@@ -77,6 +77,9 @@ TEST_F(BringupTestFixture, BasicBringupTest)
   // Ensure the status of executing the trajectory is not a timeout.
   auto goal_handle_future = control_client->async_send_goal(joint_traj_request, send_goal_options);
   ASSERT_NE(goal_handle_future.wait_for(std::chrono::seconds(5)), std::future_status::timeout);
+
+  // Sleeping for a bit helps prevent segfaults when shutting down the control node.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 }  // namespace moveit2_tutorials::quickstart_in_rviz
 

--- a/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
+++ b/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
@@ -5,6 +5,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 
+#include <chrono>
+#include <future>
 #include <gtest/gtest.h>
 #include <stdlib.h>
 
@@ -71,7 +73,10 @@ TEST_F(BringupTestFixture, BasicBringupTest)
       };
   auto send_goal_options = rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::SendGoalOptions();
   send_goal_options.result_callback = result_cb;
-  control_client->async_send_goal(joint_traj_request, send_goal_options);
+
+  // Ensure the status of executing the trajectory is not a timeout.
+  auto goal_handle_future = control_client->async_send_goal(joint_traj_request, send_goal_options);
+  ASSERT_NE(goal_handle_future.wait_for(std::chrono::seconds(5)), std::future_status::timeout);
 }
 }  // namespace moveit2_tutorials::quickstart_in_rviz
 

--- a/doc/tutorials/quickstart_in_rviz/test/bringup_test.test.py
+++ b/doc/tutorials/quickstart_in_rviz/test/bringup_test.test.py
@@ -43,7 +43,6 @@ def generate_test_description():
             ),
             base_launch,
             # The test itself
-            bringup_test,
             TimerAction(period=2.0, actions=[bringup_test]),
             launch_testing.actions.ReadyToTest(),
         ]


### PR DESCRIPTION
Note: Requires https://github.com/ros-planning/moveit2_tutorials/pull/734 to be merged in first, then I will clean up this branch

I found an issue where the bringup test was being run twice, with and without a `TimerAction`. This alone made the tests pass, but the segfault persisted at teardown.

However, adding a 1 second delay at the end of the tests made the segfault go away...

Closes https://github.com/ros-planning/moveit2_tutorials/issues/736
