### PR TITLE
Remove ambiguity in kinematics.rst

### DIFF
--- a/doc/concepts/kinematics.rst
+++ b/doc/concepts/kinematics.rst
@@ -34,6 +34,6 @@ Allowed Collision Matrix (ACM)
 
 Collision checking is a very expensive operation often accounting for close to 90% of the computational expense during motion planning.
 The ``Allowed Collision Matrix`` or ``ACM`` encodes a binary value corresponding to the need to check for collision between pairs of bodies (which could be on the robot or in the world).
-If the value corresponding to two bodies is set to ``true`` in the ACM, it specifies that a collision check between the two bodies is not required.
+If the value corresponding to two bodies is set to ``true`` in the ACM, no collision check between the two bodies will be performed.
 The collision checking would not be required if, e.g., the two bodies are always so far away that they can never collide with each other.
 Alternatively, the two bodies could be in contact with each other by default, in which case the collision detection should be disabled for the pair in the ACM.

--- a/doc/concepts/kinematics.rst
+++ b/doc/concepts/kinematics.rst
@@ -34,6 +34,6 @@ Allowed Collision Matrix (ACM)
 
 Collision checking is a very expensive operation often accounting for close to 90% of the computational expense during motion planning.
 The ``Allowed Collision Matrix`` or ``ACM`` encodes a binary value corresponding to the need to check for collision between pairs of bodies (which could be on the robot or in the world).
-If the value corresponding to two bodies is set to ``true`` in the ACM, it specifies that a collision check between the two bodies is either not required or wanted.
+If the value corresponding to two bodies is set to ``true`` in the ACM, it specifies that a collision check between the two bodies is not required.
 The collision checking would not be required if, e.g., the two bodies are always so far away that they can never collide with each other.
 Alternatively, the two bodies could be in contact with each other by default, in which case the collision detection should be disabled for the pair in the ACM.


### PR DESCRIPTION
The current phrasing ("it specifies that a collision check between the two bodies is either not required or wanted") is ambiguous. 

### Description

I guess the intended meaning was "the collision check is not required or the collision is wanted". I removed the "wanted" part to keep the wording consistent with the next sentence and remove the apparent redundancy.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
