### PR TITLE
Fix static_transform_publisher old-style argments warning

### DIFF
--- a/doc/examples/jupyter_notebook_prototyping/jupyter_notebook_prototyping_tutorial.rst
+++ b/doc/examples/jupyter_notebook_prototyping/jupyter_notebook_prototyping_tutorial.rst
@@ -121,7 +121,7 @@ Once our MoveIt configuration is defined we start the following set of nodes:
                 executable="static_transform_publisher",
                 name="static_transform_publisher",
                 output="log",
-                arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+                arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
         )
 
         robot_state_publisher = Node(

--- a/doc/examples/jupyter_notebook_prototyping/launch/jupyter_notebook_prototyping.launch.py
+++ b/doc/examples/jupyter_notebook_prototyping/launch/jupyter_notebook_prototyping.launch.py
@@ -69,7 +69,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     robot_state_publisher = Node(

--- a/doc/examples/motion_planning_python_api/launch/motion_planning_python_api_tutorial.launch.py
+++ b/doc/examples/motion_planning_python_api/launch/motion_planning_python_api_tutorial.launch.py
@@ -61,7 +61,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     robot_state_publisher = Node(

--- a/doc/examples/move_group_interface/launch/move_group.launch.py
+++ b/doc/examples/move_group_interface/launch/move_group.launch.py
@@ -46,7 +46,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/doc/examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
+++ b/doc/examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
@@ -49,7 +49,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/doc/how_to_guides/chomp_planner/launch/chomp_demo.launch.py
+++ b/doc/how_to_guides/chomp_planner/launch/chomp_demo.launch.py
@@ -79,7 +79,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
+++ b/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
     hand2camera_tf_node = Node(
         package="tf2_ros",

--- a/doc/how_to_guides/parallel_planning/launch/parallel_planning_example.launch.py
+++ b/doc/how_to_guides/parallel_planning/launch/parallel_planning_example.launch.py
@@ -127,7 +127,7 @@ def launch_setup(context, *args, **kwargs):
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/doc/how_to_guides/persistent_scenes_and_states/launch/persistent_scenes_demo.launch.py
+++ b/doc/how_to_guides/persistent_scenes_and_states/launch/persistent_scenes_demo.launch.py
@@ -80,7 +80,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/doc/how_to_guides/pick_ik/launch/demo_pick_ik.launch.py
+++ b/doc/how_to_guides/pick_ik/launch/demo_pick_ik.launch.py
@@ -83,7 +83,7 @@ def launch_setup(context, *args, **kwargs):
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/doc/how_to_guides/using_ompl_constrained_planning/launch/ompl_constrained_planning.launch.py
+++ b/doc/how_to_guides/using_ompl_constrained_planning/launch/ompl_constrained_planning.launch.py
@@ -72,7 +72,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/launch/mtc_demo.launch.py
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/launch/mtc_demo.launch.py
@@ -57,7 +57,7 @@ def generate_launch_description():
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -85,7 +85,7 @@ def launch_setup(context, *args, **kwargs):
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "base_link"],
+        arguments=["--frame-id", "world", "--child-frame-id", "base_link"],
     )
 
     # Publish TF

--- a/doc/tutorials/quickstart_in_rviz/launch/panda_demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/panda_demo.launch.py
@@ -76,7 +76,7 @@ def launch_setup(context, *args, **kwargs):
         executable="static_transform_publisher",
         name="static_transform_publisher",
         output="log",
-        arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
+        arguments=["--frame-id", "world", "--child-frame-id", "panda_link0"],
     )
 
     # Publish TF


### PR DESCRIPTION
### Description

Fix static_transform_publisher warning:
```
[WARN] [1692255660.769464305] []: Old-style arguments are deprecated; see --help for new-style arguments
```
see: https://docs.ros.org/en/rolling/Tutorials/Intermediate/Tf2/Writing-A-Tf2-Static-Broadcaster-Cpp.html#the-proper-way-to-publish-static-transforms

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
