### PR TITLE
Remove Chomp from Isaac Tutorial launch file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "ros.distro": "foxy"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "ros.distro": "foxy"
-}

--- a/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
+++ b/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
@@ -30,9 +30,7 @@ def generate_launch_description():
         )
         .robot_description_semantic(file_path="config/panda.srdf")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
-        .planning_pipelines(
-            pipelines=["ompl", "pilz_industrial_motion_planner"]
-        )
+        .planning_pipelines(pipelines=["ompl", "pilz_industrial_motion_planner"])
         .to_moveit_configs()
     )
 

--- a/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
+++ b/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
@@ -31,7 +31,7 @@ def generate_launch_description():
         .robot_description_semantic(file_path="config/panda.srdf")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
         .planning_pipelines(
-            pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"]
+            pipelines=["ompl", "pilz_industrial_motion_planner"]
         )
         .to_moveit_configs()
     )


### PR DESCRIPTION
### Description

In the Isaac tutorial if you try to run the demo.launch MoveIt would crash on startup saying it cant find the Chomp plugin. Because the tutorial does not need chomp I just removed it from the launch file.

Fixes https://github.com/ros-planning/moveit2_tutorials/issues/750

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
