### PR TITLE
add pick_ik to moveit2_tutorials.repos

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -27,3 +27,7 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_msgs
     version: ros2
+  pick_ik:
+    type: git
+    url: https://github.com/PickNikRobotics/pick_ik
+    version: main


### PR DESCRIPTION
### Description

This change adds pick_ik as a repo needed to build `moveit2_tutorials` from source. Otherwise `rosdep` will pull the precompiled packages for it and its dependencies, including moveit core packages, which may enter in conflict with the source installation.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
