### PR TITLE
Make deploy from humble use the same process as main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,12 +41,57 @@ jobs:
     - name: Run htmlproofer.sh
       run: ./htmlproofer.sh
 
-  multiversion-with-api:
+  upload_site_artifacts:
+    strategy:
+      matrix:
+        include:
+          - container: 'moveit/moveit2:rolling-source'
+            branch: 'main'
+            rosdistro: 'rolling'
+          - container: 'moveit/moveit2:humble-source'
+            branch: 'humble'
+            rosdistro: 'humble'
     runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: 'main'
+
+    - name: Install Python dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y python3-pip
+        pip3 install --upgrade --requirement requirements.txt
+
+    - name: Install doxygen and graphviz
+      run: sudo apt-get install -y doxygen graphviz
+
+    - name: Build Sphinx Artifacts
+      shell: bash
+      run: |
+        source /opt/ros/${{ matrix.rosdistro }}/setup.bash
+        source /root/ws_moveit/install/setup.bash
+        make generate_api_artifacts BRANCH=${{ matrix.branch }}
+
+    - name: Compress Artifact
+      run: tar cvzf artifact.tar.gz --directory=build/html .
+
+    - name: Upload HTML Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: '${{ matrix.branch }}_html_artifacts'
+        path: artifact.tar.gz
+
+  collate_site_artifacts:
+    runs-on: ubuntu-latest
+    needs: upload_site_artifacts
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: 'main'
 
     - uses: actions/setup-python@v4
       with:
@@ -65,11 +110,40 @@ jobs:
       with:
         ruby-version: '2.7'
 
-    - name: Build multiversion with API
-      run: make multiversion-with-api
+    # TODO (peterdavidfagan): don't hardcode branches for downloads
+    - name: Download Rolling Artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: main_html_artifacts
+        path: .
+
+    - name: Decompress Rolling Artifact
+      run: |
+        mkdir -p build/html/main
+        tar -xf artifact.tar.gz --directory=build/html/main
+        rm artifact.tar.gz
+
+    - name: Download Humble Artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: humble_html_artifacts
+        path: .
+
+    - name: Decompress Humble Artifact
+      run: |
+        mkdir -p build/html/humble
+        tar -xf artifact.tar.gz --directory=build/html/humble
+        rm artifact.tar.gz
 
     - name: Create CNAME file
       run: echo "moveit.picknik.ai" > build/html/CNAME
+
+    # TODO(henningkayser): fix hack for using python api artifact in multiversion
+    - name: Build multiversion
+      run: |
+        cp build/html/main/doc/api/python_api/api.html .   # backup artifact html
+        make multiversion
+        cp -f api.html build/html/main/doc/api/python_api/ # restore artifact html
 
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v1
@@ -80,7 +154,7 @@ jobs:
   deploy:
     if: github.repository_owner == 'ros-planning' && github.ref == 'refs/heads/humble'
     runs-on: ubuntu-latest
-    needs: multiversion-with-api
+    needs: collate_site_artifacts
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
### Description

This is the second PR directed at fixing this issue:
- https://github.com/ros-planning/moveit2_tutorials/issues/729

This one synchronizes the deploy from main to humble so it follows the same process.