### PR TITLE
Remove unused rosparam_shortcuts from workspace

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -7,10 +7,6 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_visual_tools
     version: ros2
-  rosparam_shortcuts:
-    type: git
-    url: https://github.com/PickNikRobotics/rosparam_shortcuts
-    version: ros2
   # Remove ros2_kortex when rolling binaries are available.
   ros2_kortex:
     type: git


### PR DESCRIPTION
This removes rosparam_shortcuts from the workspace because it's not used by any of the tutorials anymore.
