### PR TITLE
Change `Build Tutorial Image` CI job to only build main against Rolling

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -11,11 +11,8 @@ LABEL org.opencontainers.image.description "This container has working versions 
 # Copy MoveIt sources from docker context
 COPY . src/moveit2_tutorials
 
-# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
-# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
-RUN --mount=type=cache,target=/root/.ccache/ \
-    # Fetch required upstream sources for building
-    vcs import src < /root/ws_moveit/src/moveit2_tutorials/.github/upstream.repos
+# Fetch required upstream sources for building
+RUN vcs import src < .github/upstream.repos
 
 ######################### Hello World Tutorial  #########################################
 
@@ -28,10 +25,7 @@ RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
     --dependencies moveit_ros_planning_interface moveit_visual_tools rclcpp \
     --node-name hello_moveit hello_moveit
 
-######################### Planning Around Objects  #######################################
-
-# Remove the hello_world tutorial cpp file and replace it with the planning_around_objects file
-RUN rm src/hello_moveit/src/hello_moveit.cpp
+# Replace template hello_moveit.cpp with implementation from planning_around_objects
 COPY ./doc/tutorials/planning_around_objects/hello_moveit.cpp src/hello_moveit/src/hello_moveit.cpp
 
 ######################### Pick and Place (MTC) Image  #########################################
@@ -58,7 +52,7 @@ RUN sed -i "s|ament_package()|install(DIRECTORY launch  DESTINATION share/\${PRO
 RUN --mount=type=cache,target=/root/.ccache/ \
     # Enable ccache
     . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
-     . "install/setup.sh" &&\
+    . "install/setup.sh" &&\
     sudo apt update && rosdep install -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y && \
     sudo apt install -y ros-${ROS_DISTRO}-rmw-cyclonedds-cpp && \
     colcon build \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -8,11 +8,11 @@ FROM moveit/moveit2:${ROS_DISTRO}-source as tutorial_image
 
 LABEL org.opencontainers.image.description "This container has working versions of the tutorials discussed here: https://moveit.picknik.ai/main/doc/tutorials/tutorials.html"
 
-# Copy MoveIt sources from docker context
+# Copy sources from docker context
 COPY . src/moveit2_tutorials
 
 # Fetch required upstream sources for building
-RUN vcs import src < .github/upstream.repos
+RUN vcs import src < src/moveit2_tutorials/.github/upstream.repos
 
 ######################### Hello World Tutorial  #########################################
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -39,8 +39,7 @@ RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
         --dependencies moveit_task_constructor_core rclcpp \
         --node-name mtc_node mtc_tutorial
 
-# Remove the empty cpp file and replace it with the example file
-RUN rm src/mtc_tutorial/src/mtc_node.cpp
+# Replace template mtc_node.cpp with the example file
 COPY ./doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cpp src/mtc_tutorial/src/mtc_node.cpp
 
 # Add the launch folder to the tutorial package and CMakeLists.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 __pycache__
 **/.git
-**/.github
 **/_scripts
 **/_static
 **/_templates

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 __pycache__
 **/.git
+**/.github
 **/_scripts
 **/_static
 **/_templates

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -20,10 +20,13 @@ jobs:
 
     steps:
       - name: Checkout distro branch
-        if: ${{ matrix.ROS_DISTRO != 'rolling' }}
+        if: ${{ matrix.ROS_DISTRO }} != 'rolling'
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.ROS_DISTRO }}
+          fetch-depth: 1
+      - name: Print current branch
+        run: git branch --show-current
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 1 
+          fetch-depth: 1
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: rolling
+        ROS_DISTRO: [rolling]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -19,10 +19,6 @@ jobs:
       PUSH: ${{ (github.ref_name == 'main') }}
 
     steps:
-      - name: Checkout branch main
-        uses: actions/checkout@v4
-        with:
-          ref: main
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}
@@ -38,7 +34,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: .docker/Dockerfile
-          context: .
           build-args: |
                 ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           target: tutorial_image

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -38,6 +38,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: .docker/Dockerfile
+          context: .
           build-args: |
                 ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           target: tutorial_image

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -19,17 +19,10 @@ jobs:
       PUSH: ${{ (github.ref_name == 'main') }}
 
     steps:
-      - name: Checkout distro branch
-        if: ${{ (matrix.ROS_DISTRO != 'rolling') }}
+      - name: Checkout branch ${{ matrix.ROS_DISTRO == 'rolling' && 'main' || matrix.ROS_DISTRO }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.ROS_DISTRO }}
-          fetch-depth: 1
-      - name: Checkout main branch
-        if: ${{ (matrix.ROS_DISTRO == 'rolling') }}
-        uses: actions/checkout@v4
-        with:
-          ref: main
+          ref: ${{ matrix.ROS_DISTRO == 'rolling' && 'main' || matrix.ROS_DISTRO }}
           fetch-depth: 1
       - name: Set lower case for container name
         run: |

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -24,6 +24,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.ROS_DISTRO }}
+          fetch-depth: 1
+      - name: Checkout main branch
+        if: ${{ (matrix.ROS_DISTRO == 'rolling') }}
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1 
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.ROS_DISTRO == 'rolling' && 'main' || matrix.ROS_DISTRO }}
-          fetch-depth: 1
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -20,13 +20,10 @@ jobs:
 
     steps:
       - name: Checkout distro branch
-        if: ${{ matrix.ROS_DISTRO }} != 'rolling'
+        if: ${{ (matrix.ROS_DISTRO != 'rolling') }}
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.ROS_DISTRO }}
-          fetch-depth: 1
-      - name: Print current branch
-        run: git branch --show-current
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [humble, rolling]
+        ROS_DISTRO: rolling
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -19,10 +19,10 @@ jobs:
       PUSH: ${{ (github.ref_name == 'main') }}
 
     steps:
-      - name: Checkout branch ${{ matrix.ROS_DISTRO == 'rolling' && 'main' || matrix.ROS_DISTRO }}
+      - name: Checkout branch main
         uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.ROS_DISTRO == 'rolling' && 'main' || matrix.ROS_DISTRO }}
+          ref: main
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}


### PR DESCRIPTION
This PR started out trying to fix the CI job `Build Tutorial Image` so that it supported both `humble` and `rolling` but as we investigated further it did not make sense to build both `humble` and `main` when changes were only made to one branch. A follow up PR will be made to the `humble` branch to only build and update the corresponding image.

This is an attempt to fix the `Build Tutorial Image` step for humble. It's currently failing with the following error.

```
#18 517.2 --- stderr: hello_moveit
#18 517.2 /root/ws_moveit/src/hello_moveit/src/hello_moveit.cpp: In function 'int main(int, char**)':
#18 517.2 /root/ws_moveit/src/hello_moveit/src/hello_moveit.cpp:107:36: error: 'std::tuple_element<1, const std::pair<bool, moveit::planning_interface::MoveGroupInterface::Plan> >::type' {aka 'const struct moveit::planning_interface::MoveGroupInterface::Plan'} has no member named 'trajectory'; did you mean 'trajectory_'?
#18 517.2   107 |     draw_trajectory_tool_path(plan.trajectory);
#18 517.2       |                                    ^~~~~~~~~~
#18 517.2       |                                    trajectory_
#18 517.2 gmake[2]: *** [CMakeFiles/hello_moveit.dir/build.make:76: CMakeFiles/hello_moveit.dir/src/hello_moveit.cpp.o] Error 1
```
