### PR TITLE
Change Build Tutorial Image CI job to only build humble branch against Humble

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -8,14 +8,11 @@ FROM moveit/moveit2:${ROS_DISTRO}-source as tutorial_image
 
 LABEL org.opencontainers.image.description "This container has working versions of the tutorials discussed here: https://moveit.picknik.ai/main/doc/tutorials/tutorials.html"
 
-# Copy MoveIt sources from docker context
+# Copy sources from docker context
 COPY . src/moveit2_tutorials
 
-# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
-# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
-RUN --mount=type=cache,target=/root/.ccache/ \
-    # Fetch required upstream sources for building
-    vcs import src < /root/ws_moveit/src/moveit2_tutorials/.github/upstream.repos
+# Fetch required upstream sources for building
+RUN vcs import src < src/moveit2_tutorials/.github/upstream.repos
 
 ######################### Hello World Tutorial  #########################################
 
@@ -30,8 +27,7 @@ RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
 
 ######################### Planning Around Objects  #######################################
 
-#Remove the hello_world tutorial cpp file and replace it with the planning_around_objects file
-RUN rm src/hello_moveit/src/hello_moveit.cpp
+# Replace template hello_moveit.cpp with implementation from planning_around_objects
 COPY ./doc/tutorials/planning_around_objects/hello_moveit.cpp src/hello_moveit/src/hello_moveit.cpp
 
 ######################### Pick and Place (MTC) Image  #########################################
@@ -45,8 +41,7 @@ RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
         --dependencies moveit_task_constructor_core rclcpp \
         --node-name mtc_node mtc_tutorial
 
-#Remove the empty cpp file and replace it with the example file
-RUN rm src/mtc_tutorial/src/mtc_node.cpp
+# Replace template mtc_node.cpp with the example file
 COPY ./doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cpp src/mtc_tutorial/src/mtc_node.cpp
 
 #Add the launch folder to the tutorial package and CMakeLists.txt
@@ -58,7 +53,7 @@ RUN   sed -i "s|ament_package()|install(DIRECTORY launch  DESTINATION share/\${P
 RUN --mount=type=cache,target=/root/.ccache/ \
     # Enable ccache
     . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
-     . "install/setup.sh" &&\
+    . "install/setup.sh" &&\
     sudo apt update && rosdep install -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y && \
     sudo apt install -y ros-${ROS_DISTRO}-rmw-cyclonedds-cpp && \
     colcon build \

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 __pycache__
 **/.git
-**/.github
 **/_scripts
 **/_static
 **/_templates

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 __pycache__
 **/.git
+**/.github
 **/_scripts
 **/_static
 **/_templates

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,11 @@ jobs:
     name: ${{ matrix.env.IMAGE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: cache upstream_ws
-        uses: pat-s/always-upload-cache@v2.1.5
+        uses: pat-s/always-upload-cache@v3.0.11
         with:
           path: ${{ env.BASEDIR }}/upstream_ws
           key: upstream_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('.github/upstream.repos') }}-${{ github.run_id }}
@@ -49,14 +49,14 @@ jobs:
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws
-        uses: pat-s/always-upload-cache@v2.1.5
+        uses: pat-s/always-upload-cache@v3.0.11
         with:
           path: ${{ env.BASEDIR }}/target_ws
           key: target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}-${{ github.run_id }}
           restore-keys: |
             target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
-        uses: pat-s/always-upload-cache@v2.1.5
+        uses: pat-s/always-upload-cache@v3.0.11
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,7 @@ jobs:
   htmlproofer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v4
       with:
@@ -55,7 +53,7 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: 'main'
 
@@ -88,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: upload_site_artifacts
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: 'main'
@@ -146,7 +144,7 @@ jobs:
         cp -f api.html build/html/main/doc/api/python_api/ # restore artifact html
 
     - name: Upload pages artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v2
       if: github.repository_owner == 'ros-planning'
       with:
         path: build/html

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -19,10 +19,6 @@ jobs:
       PUSH: ${{ (github.ref_name == 'main') }}
 
     steps:
-      - name: Checkout humble branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.ROS_DISTRO }}
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}
@@ -38,10 +34,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: .docker/Dockerfile
-          context: .
           build-args: |
                 ROS_DISTRO=${{ matrix.ROS_DISTRO }}
-                BASE_BRANCH=${{ env.BASE_IMAGE_BRANCH }}
           target: tutorial_image
           push: ${{ env.PUSH }}
           no-cache: false

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -23,15 +23,15 @@ jobs:
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to Github Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Tutorial Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           file: .docker/Dockerfile
           build-args: |

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [humble, rolling]
+        ROS_DISTRO: [humble]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -19,6 +19,10 @@ jobs:
       PUSH: ${{ (github.ref_name == 'main') }}
 
     steps:
+      - name: Checkout humble branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.ROS_DISTRO }}
       - name: Set lower case for container name
         run: |
           echo "GH_IMAGE_LC=${GH_IMAGE,,}" >>${GITHUB_ENV}
@@ -34,6 +38,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: .docker/Dockerfile
+          context: .
           build-args: |
                 ROS_DISTRO=${{ matrix.ROS_DISTRO }}
                 BASE_BRANCH=${{ env.BASE_IMAGE_BRANCH }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'


### PR DESCRIPTION
This is the follow up to #782 so that changes to the `humble` branch only build a Humble docker image.
