### PR TITLE
Remove the note about doing a shallow checkout of tutorials

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -60,7 +60,7 @@ Download Source Code of MoveIt and the Tutorials
 Move into your Colcon workspace and pull the MoveIt tutorials source: ::
 
   cd ~/ws_moveit/src
-  git clone https://github.com/ros-planning/moveit2_tutorials -b main --depth 1
+  git clone https://github.com/ros-planning/moveit2_tutorials
 
 Next we will download the source code for the rest of MoveIt: ::
 


### PR DESCRIPTION
### Description

Since I cleaned up the history of the git repo to remove the output of the statically generated site, this repo is now much faster to clone. It is generally a better git experience to have a normal clone instead of a shallow one when contributing.

```
time git clone https://github.com/ros-planning/moveit2_tutorials
Cloning into 'moveit2_tutorials'...
remote: Enumerating objects: 7736, done.
remote: Counting objects: 100% (1142/1142), done.
remote: Compressing objects: 100% (688/688), done.
remote: Total 7736 (delta 636), reused 828 (delta 442), pack-reused 6594
Receiving objects: 100% (7736/7736), 91.83 MiB | 11.03 MiB/s, done.
Resolving deltas: 100% (4638/4638), done.

________________________________________________________
Executed in   11.08 secs    fish           external
   usr time    1.17 secs  241.00 micros    1.17 secs
   sys time    0.49 secs  297.00 micros    0.49 secs
```