### PR TITLE
moveit_py: fix motion planning tutorial configs

### DIFF
--- a/doc/examples/motion_planning_python_api/config/motion_planning_python_api_tutorial.yaml
+++ b/doc/examples/motion_planning_python_api/config/motion_planning_python_api_tutorial.yaml
@@ -41,4 +41,3 @@ chomp_planner:
     max_velocity_scaling_factor: 1.0
     max_acceleration_scaling_factor: 1.0
     planning_time: 1.5
-

--- a/doc/examples/motion_planning_python_api/config/motion_planning_python_api_tutorial.yaml
+++ b/doc/examples/motion_planning_python_api/config/motion_planning_python_api_tutorial.yaml
@@ -8,7 +8,7 @@ planning_scene_monitor_options:
   wait_for_initial_state_timeout: 10.0
 
 planning_pipelines:
-  pipeline_names: ["ompl", "pilz_industrial_motion_planner", "chomp", "ompl_rrt_star"]
+  pipeline_names: ["ompl", "pilz_industrial_motion_planner", "chomp"]
 
 plan_request_params:
   planning_attempts: 1
@@ -34,7 +34,7 @@ pilz_lin:
     max_acceleration_scaling_factor: 1.0
     planning_time: 0.8
 
-chomp:
+chomp_planner:
   plan_request_params:
     planning_attempts: 1
     planning_pipeline: chomp
@@ -42,12 +42,3 @@ chomp:
     max_acceleration_scaling_factor: 1.0
     planning_time: 1.5
 
-# Second OMPL pipeline
-ompl_rrt_star:
-  plan_request_params:
-    planning_attempts: 1
-    planning_pipeline: ompl_rrt_star # Different OMPL pipeline name!
-    planner_id: "RRTstarkConfigDefault"
-    max_velocity_scaling_factor: 1.0
-    max_acceleration_scaling_factor: 1.0
-    planning_time: 1.5

--- a/doc/examples/motion_planning_python_api/scripts/motion_planning_python_api_tutorial.py
+++ b/doc/examples/motion_planning_python_api/scripts/motion_planning_python_api_tutorial.py
@@ -159,7 +159,7 @@ def main():
 
     # initialise multi-pipeline plan request parameters
     multi_pipeline_plan_request_params = MultiPipelinePlanRequestParameters(
-        panda, ["ompl_rrtc", "pilz_lin", "chomp", "ompl_rrt_star"]
+        panda, ["ompl_rrtc", "pilz_lin", "chomp_planner"]
     )
 
     # plan to goal


### PR DESCRIPTION
### Description

As outlined [here](https://github.com/ros-planning/moveit2_tutorials/issues/724), users were encountering errors due to the config file in the motion planning tutorial for the Python API.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers
