### PR TITLE
Update Isaac tutorial to use main-humble-tutorial-source docker image

### DIFF
--- a/doc/how_to_guides/isaac_panda/.docker/Dockerfile
+++ b/doc/how_to_guides/isaac_panda/.docker/Dockerfile
@@ -1,23 +1,17 @@
-FROM osrf/ros:humble-desktop-jammy
+FROM moveit/moveit2:main-tutorial-humble-tutorial-source
 
 SHELL ["/bin/bash", "-c", "-o", "pipefail"]
 
 ARG CUDA_MAJOR_VERSION=11
 ARG CUDA_MINOR_VERSION=7
 
-RUN echo "deb [trusted=yes] https://raw.githubusercontent.com/moveit/moveit2_packages/jammy-humble/ ./" \
-    | sudo tee /etc/apt/sources.list.d/moveit_moveit2_packages.list
-RUN echo "yaml https://raw.githubusercontent.com/moveit/moveit2_packages/jammy-humble/local.yaml humble" \
-    | sudo tee /etc/ros/rosdep/sources.list.d/1-moveit_moveit2_packages.list
-
-# Bring the container up to date to get the latest ROS2 humble sync on 01/27/23
+# Bring the container up to date to get the latest ROS sync
 # hadolint ignore=DL3008, DL3013
 RUN apt-get update && apt-get upgrade -y && rosdep update
 
 # Install packages required to run the demo
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-humble-moveit \
-    ros-humble-moveit-resources \
+    ros-humble-topic-based-ros2-control \
     wget \
     python3-pip
 
@@ -33,18 +27,6 @@ ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:$LD_LIBRARY_PA
 # Install pytorch
 RUN pip3 install torch torchvision
 
-# Create Colcon workspace and clone the needed source code to run the demo
-RUN mkdir -p /root/isaac_moveit_tutorial_ws/src
-WORKDIR /root/isaac_moveit_tutorial_ws/src
-RUN git clone https://github.com/PickNikRobotics/topic_based_ros2_control.git
-COPY ./ moveit2_tutorials
-WORKDIR /root/isaac_moveit_tutorial_ws
-# hadolint ignore=SC1091
-RUN source /opt/ros/humble/setup.bash \
-    && apt-get update -y \
-    && rosdep install --from-paths src --ignore-src --rosdistro "$ROS_DISTRO" -y \
-    && rm -rf /var/lib/apt/lists/*
-
 # Use Fast DDS as middleware and load the required config for NVIDIA Isaac Sim.
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
 RUN mkdir -p /opt/.ros
@@ -54,9 +36,6 @@ ENV FASTRTPS_DEFAULT_PROFILES_FILE=/opt/.ros/fastdds.xml
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 ENV NVIDIA_REQUIRE_CUDA "cuda>=${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}"
-
-# Build the Colcon workspace for the user
-RUN source /opt/ros/humble/setup.bash && colcon build
 
 # Set up the entrypoint for both container start and interactive terminals.
 COPY ./doc/how_to_guides/isaac_panda/.docker/ros_entrypoint.sh /opt/.ros/

--- a/doc/how_to_guides/isaac_panda/.docker/Dockerfile
+++ b/doc/how_to_guides/isaac_panda/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM moveit/moveit2:main-tutorial-humble-tutorial-source
+FROM moveit/moveit2:main-humble-tutorial-source
 
 SHELL ["/bin/bash", "-c", "-o", "pipefail"]
 

--- a/doc/how_to_guides/isaac_panda/.docker/ros_entrypoint.sh
+++ b/doc/how_to_guides/isaac_panda/.docker/ros_entrypoint.sh
@@ -1,18 +1,9 @@
 #!/bin/bash
 
-# Source ROS 2 Humble
+# Source ROS and the MoveIt2 workspace
 source /opt/ros/humble/setup.bash
-echo "Sourced ROS 2 Humble"
-
-# Source the base workspace, if built
-if [ -f /root/isaac_moveit_tutorial_ws/install/setup.bash ]
-then
-  source /root/isaac_moveit_tutorial_ws/install/setup.bash
-  echo "Sourced isaac_moveit_tutorial workspace"
-else
-  echo "Please build the isaac_moveit_tutorial workspace with:"
-  echo "colcon build"
-fi
+source /root/ws_moveit/install/setup.bash
+echo "Sourced ROS & MoveIt Humble"
 
 # Execute the command passed into this entrypoint
 exec "$@"

--- a/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.rst
+++ b/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.rst
@@ -74,7 +74,7 @@ Computer Setup
 
 .. code-block:: bash
 
-  git clone https://github.com/ros-planning/moveit2_tutorials.git -b main --depth 1
+  git clone https://github.com/ros-planning/moveit2_tutorials.git -b main
 
 3. Go to the folder in which you cloned the tutorials and then switch to the following directory.
 


### PR DESCRIPTION
Current Isaac tutorial is broken because the [custom binary images for MoveIt2](https://github.com/moveit/moveit2_packages/issues/6) have stopped being updated. This PR updates the Isaac tutorial docker image to use the [new source build containers](https://github.com/ros-planning/moveit2/pkgs/container/moveit2) @tylerjw recently added :1st_place_medal:.

Tutorial now gets all required ROS packages from the new MoveIt container and topic_based_ros2_control from binary.
