### PR TITLE
Update instructions for Pilz tutorial

### DIFF
--- a/doc/how_to_guides/pilz_industrial_motion_planner/pilz_industrial_motion_planner.rst
+++ b/doc/how_to_guides/pilz_industrial_motion_planner/pilz_industrial_motion_planner.rst
@@ -267,7 +267,7 @@ By running
 
 ::
 
-    ros2 launch moveit2_tutorials demo.launch.py rviz_config:=panda_hello_moveit.rviz
+    ros2 launch moveit_resources_panda_moveit_config demo.launch.py
 
 you can interact with the planner through the RViz MotionPlanning panel.
 
@@ -280,7 +280,7 @@ To run this, execute the following commands in separate Terminals:
 
 ::
 
-    ros2 launch moveit2_tutorials demo.launch.py rviz_config:=panda_hello_moveit.rviz
+    ros2 launch moveit_resources_panda_moveit_config demo.launch.py
     ros2 run moveit2_tutorials pilz_move_group
 
 

--- a/doc/how_to_guides/pilz_industrial_motion_planner/src/pilz_move_group.cpp
+++ b/doc/how_to_guides/pilz_industrial_motion_planner/src/pilz_move_group.cpp
@@ -9,7 +9,7 @@
  * Pilz Example -- MoveGroup Interface
  *
  * To run this example, first run this launch file:
- * ros2 launch moveit2_tutorials demo.launch.py rviz_config:=panda_hello_moveit.rviz
+ * ros2 launch moveit_resources_panda_moveit_config demo.launch.py
  *
  * For best results, hide the "MotionPlanning" widget in RViz.
  *
@@ -30,7 +30,7 @@ int main(int argc, char* argv[])
   auto spinner = std::thread([&executor]() { executor.spin(); });
 
   // Create a ROS logger
-  auto const logger = rclcpp::get_logger("pilz_move_group");
+  auto const logger = rclcpp::get_logger("pilz_move_group_node");
 
   // Create the MoveIt MoveGroup Interface
   using moveit::planning_interface::MoveGroupInterface;

--- a/doc/how_to_guides/pilz_industrial_motion_planner/src/pilz_mtc.cpp
+++ b/doc/how_to_guides/pilz_industrial_motion_planner/src/pilz_mtc.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-static const rclcpp::Logger LOGGER = rclcpp::get_logger("pilz_mtc");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("pilz_mtc_node");
 namespace mtc = moveit::task_constructor;
 
 class MTCTaskNode

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -2,10 +2,8 @@ import os
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch.conditions import IfCondition, UnlessCondition
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch.actions import ExecuteProcess
 from ament_index_python.packages import get_package_share_directory
 from moveit_configs_utils import MoveItConfigsBuilder
 

--- a/doc/tutorials/your_first_project/your_first_project.rst
+++ b/doc/tutorials/your_first_project/your_first_project.rst
@@ -268,13 +268,16 @@ Summary
 
 * You created a ROS 2 package and wrote your first program using MoveIt.
 * You learned about using the MoveGroupInterface to plan and execute moves.
-* :codedir:`Here is a copy of the full hello_moveit.cpp source at the end of this tutorial<tutorials/your_first_project/hello_moveit.cpp>`.
+* :codedir:`Here is a copy of the full hello_moveit.cpp source at the end of this tutorial<tutorials/your_first_project/kinova_hello_moveit.cpp>`.
 
 Further Reading
 ---------------
 
-- We used lambdas to be able to initialize objects as constants. This is known as a technique called IIFE.  `Read more about this pattern from C++ Stories <https://www.cppstories.com/2016/11/iife-for-complex-initialization/>`_.
-- We also declared everything we could as const.  `Read more about the usefulness of const here <https://www.cppstories.com/2016/12/please-declare-your-variables-as-const/>`_.
+- We used lambdas to be able to initialize objects as constants.
+  This is known as a technique called IIFE.
+  `Read more about this pattern from C++ Stories <https://www.cppstories.com/2016/11/iife-for-complex-initialization/>`_.
+- We also declared everything we could as const.
+  `Read more about the usefulness of const here <https://www.cppstories.com/2016/12/please-declare-your-variables-as-const/>`_.
 
 Next Step
 ---------


### PR DESCRIPTION
Along with https://github.com/ros-planning/moveit_resources/pull/190, this PR fixes the Pilz tutorial to work again.

Closes https://github.com/ros-planning/moveit2_tutorials/issues/795
