### PR TITLE
Remove recommendation for Cyclone due to FastDDS issues

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -53,7 +53,6 @@ RUN --mount=type=cache,target=/root/.ccache/ \
     . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
     . "install/setup.sh" &&\
     sudo apt update && rosdep install -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y && \
-    sudo apt install -y ros-${ROS_DISTRO}-rmw-cyclonedds-cpp && \
     colcon build \
         --cmake-args -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                      -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -63,6 +62,5 @@ RUN --mount=type=cache,target=/root/.ccache/ \
     rm -rf /var/lib/apt/lists/* && \
     # Update /ros_entrypoint.sh to source our new workspace
     sed -i "s#/opt/ros/\$ROS_DISTRO/setup.bash#$ROS_UNDERLAY/install/setup.bash#g" /ros_entrypoint.sh && \
-    echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /root/.bashrc && \
     echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /root/.bashrc && \
     echo "source /root/ws_moveit/install/setup.bash" >> /root/.bashrc

--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -108,19 +108,6 @@ Optional: add the previous command to your ``.bashrc``: ::
    not required and often skipped by advanced users who use more than one
    Colcon workspace at a time, but we recommend it for simplicity.
 
-.. _cyclone_dds:
-
-Switch to Cyclone DDS
-^^^^^^^^^^^^^^^^^^^^^
-
-As of Sep 26, 2022, the default ROS 2 middleware (RMW) implementation has an issue.
-As a workaround, switch to Cyclone DDS.
-(Note: this makes all nodes started using this RMW incompatible with any other nodes not using Cyclone DDS.) ::
-
-  sudo apt install ros-rolling-rmw-cyclonedds-cpp
-  # You may want to add this to ~/.bashrc to source it automatically
-  export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-
 Next Step
 ^^^^^^^^^
 Nice job!

--- a/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -9,7 +9,6 @@ Getting Started
 ---------------
 If you haven't already done so, make sure you've completed the steps in :doc:`Getting Started </doc/tutorials/getting_started/getting_started>` or our :doc:`Docker Guide </doc/how_to_guides/how_to_setup_docker_containers_in_ubuntu>`.
 If you followed the Docker Guide, also follow the :ref:`create_colcon_workspace` guide onwards to set up the tutorials.
-As of Sep 26, 2022, ensure you have :ref:`enabled Cyclone DDS <cyclone_dds>`.
 
 Step 1: Launch the Demo and Configure the Plugin
 ------------------------------------------------


### PR DESCRIPTION
We don't have any open [issues with FastDDS](https://github.com/ros-planning/moveit2/issues/1874) anymore, everything is running fine per our knowledge. Let's remove this recommendation.