### PR TITLE
Fixed docs: Clone correct moveit2_tutorials branch for Humble

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -47,7 +47,7 @@ Download Source Code of MoveIt and the Tutorials
 Move into your Colcon workspace and pull the MoveIt tutorials source: ::
 
   cd ~/ws_moveit/src
-  git clone https://github.com/ros-planning/moveit2_tutorials
+  git clone -b humble https://github.com/ros-planning/moveit2_tutorials
 
 Next we will download the source code for the rest of MoveIt: ::
 


### PR DESCRIPTION
### Description
Added the branch command to clone the humble branch of the `moveit2_tutorials` repo to make sure there are no compatibility issues with ROS 2 Humble.

Please explain the changes you made, including a reference to the related issue if applicable
Added the `-b humble` flag to line

> 50 | git clone https://github.com/ros-planning/moveit2_tutorials

on the Getting started tutorial.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
