### PR TITLE
Clone humble branch of tutorials

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -47,7 +47,7 @@ Download Source Code of MoveIt and the Tutorials
 Move into your Colcon workspace and pull the MoveIt tutorials source: ::
 
   cd ~/ws_moveit/src
-  git clone https://github.com/ros-planning/moveit2_tutorials
+  git clone --branch {DISTRO} https://github.com/ros-planning/moveit2_tutorials
 
 Next we will download the source code for the rest of MoveIt: ::
 


### PR DESCRIPTION
People frequently run into issues due to changed API between MoveIt Humble and main, e.g. https://github.com/ros-planning/moveit_task_constructor/pull/508. 

Additionally to more clearly emphasizing, which tutorial to use (unfortunately, the corresponding combobox to select the version was removed at some point), the humble version should only clone the humble branch of the tutorials.