### PR TITLE
fix cd command

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -46,7 +46,7 @@ Download Source Code of MoveIt and the Tutorials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Move into your Colcon workspace and pull the MoveIt tutorials source: ::
 
-  cd ~/ws_moveit/src
+  cd ~/ws_moveit2/src
   git clone -b humble https://github.com/ros-planning/moveit2_tutorials
 
 Next we will download the source code for the rest of MoveIt: ::


### PR DESCRIPTION
workspace name was inconsistent with others.

### Description

Stumbled upon this while setting up tutorial, cd command refers to directory that does not exist.
changed directory name to allign with others in tutorial.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
