### PR TITLE
Fix CI 

### DIFF
--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -20,8 +20,13 @@ repositories:
     type: git
     url: https://github.com/Kinovarobotics/ros2_kortex.git
     version: main
-  # Remove ros2_robotiq_gripper when rolling binaries are available
+  # Remove ros2_robotiq_gripper when rolling binaries are available.
   ros2_robotiq_gripper:
     type: git
     url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
     version: main
+  # Serial is a dependency of ros2_robotiq_gripper. Remove when ros2_robotiq_gripper binaries are available.
+  serial:
+    type: git
+    url: https://github.com/tylerjw/serial.git
+    version: ros2

--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -15,3 +15,8 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git
     version: ros2
+  # Remove ros2_kortex when rolling binaries are available.
+  ros2_kortex:
+    type: git
+    url: https://github.com/Kinovarobotics/ros2_kortex.git
+    version: main

--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -19,4 +19,4 @@ repositories:
   ros2_kortex:
     type: git
     url: https://github.com/Kinovarobotics/ros2_kortex.git
-    version: main
+    version: 740d21b

--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -19,4 +19,9 @@ repositories:
   ros2_kortex:
     type: git
     url: https://github.com/Kinovarobotics/ros2_kortex.git
-    version: 740d21b
+    version: main
+  # Remove ros2_robotiq_gripper when rolling binaries are available
+  ros2_robotiq_gripper:
+    type: git
+    url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+    version: main

--- a/doc/examples/planning_adapters/planning_adapters_tutorial.rst
+++ b/doc/examples/planning_adapters/planning_adapters_tutorial.rst
@@ -53,7 +53,7 @@ To achieve this, follow the steps:
                 default_planner_request_adapters/FixStartStatePathConstraints
                 chomp/OptimizerAdapter" />
 
-#. The values of the ``planning_adapters`` is the order in which the mentioned adapters are called / invoked. Order here matters. Inside the CHOMP adapter, a :moveit_codedir:`call <moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp#L169>` to OMPL is made before invoking the CHOMP optimization solver, so CHOMP takes the initial path computed by OMPL as the starting point to further optimize it.
+#. The values of the ``planning_adapters`` is the order in which the mentioned adapters are called / invoked. Order here matters. Inside the CHOMP adapter, a call to OMPL is made before invoking the CHOMP optimization solver, so CHOMP takes the initial path computed by OMPL as the starting point to further optimize it.
 
 #. Find the line where ``<rosparam command="load" file="$(find panda_moveit_config)/config/ompl_planning.yaml"/>`` is mentioned and after this line, add the following: ::
 

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -12,6 +12,16 @@ repositories:
     type: git
     url: https://github.com/Kinovarobotics/ros2_kortex.git
     version: main
+  # Remove ros2_robotiq_gripper when rolling binaries are available.
+  ros2_robotiq_gripper:
+    type: git
+    url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+    version: main
+  # Serial is a dependency of ros2_robotiq_gripper. Remove when ros2_robotiq_gripper binaries are available.
+  serial:
+    type: git
+    url: https://github.com/tylerjw/serial.git
+    version: ros2
   rviz_visual_tools:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -11,7 +11,7 @@ repositories:
   ros2_kortex:
     type: git
     url: https://github.com/Kinovarobotics/ros2_kortex.git
-    version: 740d21b
+    version: main
   rviz_visual_tools:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -11,7 +11,7 @@ repositories:
   ros2_kortex:
     type: git
     url: https://github.com/Kinovarobotics/ros2_kortex.git
-    version: main
+    version: 740d21b
   rviz_visual_tools:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
* Adding `ros2_kortex` as a source build since CI is failing as it does not have the latest changes in `ros2_kortex` repo regarding the planning pipeline refactor.
Fixing the ros2_kortex repo to 
```
[move_group-4] terminate called after throwing an instance of 'rclcpp::ParameterTypeException'
[move_group-4]   what():  expected [string_array] got [string]
```
* Also, added `ros2_robotiq_gripper` repo as a source build to fix the invalid parameter error - https://github.com/ros-planning/moveit2_tutorials/issues/821

* This PR also brings in https://github.com/Kinovarobotics/ros2_kortex/pull/197 to fix the `fake_components` deprecation.

