### PR TITLE
[MTC tutorial] Use launch files instead of running executable 

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -71,8 +71,8 @@ For all demos you should launch the basic environment: ::
 
 Subsequently, you can run the individual demos: ::
 
-  ros2 run moveit_task_constructor_demo cartesian
-  ros2 run moveit_task_constructor_demo modular
+  ros2 run moveit_task_constructor_demo cartesian.launch.py
+  ros2 run moveit_task_constructor_demo modular.launch.py
   ros2 launch moveit_task_constructor_demo pickplace.launch.py
 
 On the right side you should see the **Motion Planning Tasks** panel outlining the hierarchical stage structure of the tasks.


### PR DESCRIPTION
### Description

The MTC tutorial tells users to run executables which will fail since they need parameters to be passed into the node. Use the launch files while are already available instead.

### How To Test
Run 
```
ros2 launch moveit_task_constructor_demo demo.launch.py
```
and 
```
ros2 launch moveit_task_constructor_demo cartesian.launch.py 
ros2 launch moveit_task_constructor_demo modular.launch.py 
```

### Proof that it works
Cartesian
https://github.com/ros-planning/moveit2_tutorials/assets/17363793/d575d987-5e1f-45f4-80be-c54b936a2a62

Modular
https://github.com/ros-planning/moveit2_tutorials/assets/17363793/fd2256b6-e2ae-44ab-880b-13f0cd67faf0



