### PR TITLE
Fix parameters in motion planning API tutorial

### DIFF
--- a/doc/examples/motion_planning_api/launch/motion_planning_api_tutorial.launch.py
+++ b/doc/examples/motion_planning_api/launch/motion_planning_api_tutorial.launch.py
@@ -1,54 +1,17 @@
-import os
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
-
-
-def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, "r") as file:
-            return file.read()
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
-        return None
-
-
-def load_yaml(package_name, file_path):
-    package_path = get_package_share_directory(package_name)
-    absolute_file_path = os.path.join(package_path, file_path)
-
-    try:
-        with open(absolute_file_path, "r") as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
-        return None
+from moveit_configs_utils import MoveItConfigsBuilder
 
 
 def generate_launch_description():
-    robot_description_config = load_file(
-        "moveit_resources_panda_description", "urdf/panda.urdf"
+    moveit_config = (
+        MoveItConfigsBuilder("moveit_resources_panda")
+            .robot_description(file_path="config/panda.urdf.xacro")
+            .robot_description_semantic(file_path="config/panda.srdf")
+            .trajectory_execution(file_path="config/moveit_controllers.yaml")
+            .planning_pipelines(pipelines=["ompl"])
+            .to_moveit_configs()
     )
-    robot_description = {"robot_description": robot_description_config}
-
-    robot_description_semantic_config = load_file(
-        "moveit_resources_panda_moveit_config", "config/panda.srdf"
-    )
-    robot_description_semantic = {
-        "robot_description_semantic": robot_description_semantic_config
-    }
-
-    kinematics_yaml = load_yaml(
-        "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
-    )
-
-    planning_yaml = load_yaml(
-        "moveit_resources_panda_moveit_config", "config/ompl_planning.yaml"
-    )
-
-    planning_plugin = {"planning_plugin": "ompl_interface/OMPLPlanner"}
 
     return LaunchDescription(
         [
@@ -56,13 +19,8 @@ def generate_launch_description():
                 package="moveit2_tutorials",
                 executable="motion_planning_api_tutorial",
                 name="motion_planning_api_tutorial",
-                parameters=[
-                    robot_description,
-                    robot_description_semantic,
-                    kinematics_yaml,
-                    planning_yaml,
-                    planning_plugin,
-                ],
+                output="screen",
+                parameters=[moveit_config.to_dict()],
             )
         ]
     )

--- a/doc/examples/motion_planning_api/launch/motion_planning_api_tutorial.launch.py
+++ b/doc/examples/motion_planning_api/launch/motion_planning_api_tutorial.launch.py
@@ -6,11 +6,11 @@ from moveit_configs_utils import MoveItConfigsBuilder
 def generate_launch_description():
     moveit_config = (
         MoveItConfigsBuilder("moveit_resources_panda")
-            .robot_description(file_path="config/panda.urdf.xacro")
-            .robot_description_semantic(file_path="config/panda.srdf")
-            .trajectory_execution(file_path="config/moveit_controllers.yaml")
-            .planning_pipelines(pipelines=["ompl"])
-            .to_moveit_configs()
+        .robot_description(file_path="config/panda.urdf.xacro")
+        .robot_description_semantic(file_path="config/panda.srdf")
+        .trajectory_execution(file_path="config/moveit_controllers.yaml")
+        .planning_pipelines(pipelines=["ompl"])
+        .to_moveit_configs()
     )
 
     return LaunchDescription(

--- a/doc/examples/motion_planning_api/src/motion_planning_api_tutorial.cpp
+++ b/doc/examples/motion_planning_api/src/motion_planning_api_tutorial.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
   // We will get the name of planning plugin we want to load
   // from the ROS parameter server, and then load the planner
   // making sure to catch all exceptions.
-  if (!motion_planning_api_tutorial_node->get_parameter("planning_plugin", planner_plugin_name))
+  if (!motion_planning_api_tutorial_node->get_parameter("ompl.planning_plugin", planner_plugin_name))
     RCLCPP_FATAL(LOGGER, "Could not find planner plugin name");
   try
   {


### PR DESCRIPTION
### Description
Fixes https://github.com/ros-planning/moveit2_tutorials/issues/823

I changed the launch file for the `motion_planning_api_tutorial` tutorial to accommodate the parameter namespace Moveit2 currently uses for loading plugins. For example, before the kinematic solver was loaded using a parameter called `panda_arm.kinematics_solver` and now it uses `robot_description_kinematics.panda_arm.kinematics_solver` which is the result of using the `MoveItConfigsBuilder`.    

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
