### PR TITLE
Fix minor typo in getting_started.rst

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -89,7 +89,7 @@ This build command will likely take a long time (20+ minutes) depending on your 
 .. warning::
   Some of the packages built with this command require up to 16Gb of RAM to build. By default, ``colcon``  tries to build as many packages as possible at the same time.
   If you are low on computer memory, or if the build is generally having trouble completing on your computer,
-  you can try appending ``--executor sequential`` to the ``colcon`` command above to build only one package at a time, or ``-parallel-workers <X>`` to limit the number of simultaneous builds.
+  you can try appending ``--executor sequential`` to the ``colcon`` command above to build only one package at a time, or ``--parallel-workers <X>`` to limit the number of simultaneous builds.
 
 If everything goes well, you should see the message "Summary: X packages finished" where X might be 50. If you have problems, try re-checking your `ROS Installation <https://docs.ros.org/en/rolling/Installation.html>`_.
 


### PR DESCRIPTION
### Description

https://colcon.readthedocs.io/en/released/reference/executor-arguments.html#:~:text=%2D%2Dparallel%2Dworkers%20NUMBER

While going through the tutorial for MoveIt2 I noticed a minor type in the warning for the compilation step. Note: No formatting was changed, so I am skipping the `clang-format` check.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
