### PR TITLE
Check for and fix misspelled MoveIt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         name: misspelled-moveit
         description: MoveIt should be spelled exactly as MoveIt
         language: pygrep
-        entry: Moveit\W|MoveIt!
+        entry: Moveit\W|MoveIt!|Moveit2|MoveIt2
         exclude: .pre-commit-config.yaml
       - id: clang-format
         name: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: misspelled-moveit
+        name: misspelled-moveit
+        description: MoveIt should be spelled exactly as MoveIt
+        language: pygrep
+        entry: Moveit\W|MoveIt!
+        exclude: .pre-commit-config.yaml
       - id: clang-format
         name: clang-format
         description: Format files with ClangFormat.

--- a/doc/examples/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/examples/controller_configuration/controller_configuration_tutorial.rst
@@ -6,7 +6,7 @@ MoveIt typically publishes manipulator motion commands to a `JointTrajectoryCont
 
 #. A launch file. This launch file must load the :code:`moveit_controllers` yaml file and specify the :code:`moveit_simple_controller_manager/MoveItSimpleControllerManager`. After these yaml files are loaded, they are passed as parameters to the Move Group node. `Example Move Group launch file <https://github.com/ros-planning/moveit_resources/blob/ros2/panda_moveit_config/launch/demo.launch.py>`_.
 
-#. Launch the corresponding :code:`ros2_control` JointTrajectoryControllers. This is separate from the MoveIt2 ecosystem. `Example ros2_control launching <https://github.com/ros-controls/ros2_control_demos>`_. Each JointTrajectoryController provides an action interface. Given the yaml file above, MoveIt automatically connects to this action interface.
+#. Launch the corresponding :code:`ros2_control` JointTrajectoryControllers. This is separate from the MoveIt 2 ecosystem. `Example ros2_control launching <https://github.com/ros-controls/ros2_control_demos>`_. Each JointTrajectoryController provides an action interface. Given the yaml file above, MoveIt automatically connects to this action interface.
 
 #. Note: it is not required to use :code:`ros2_control` for your robot. You could write a proprietary action interface. In practice, 99% of users choose :code:`ros2_control`.
 

--- a/doc/examples/creating_moveit_plugins/lerp_motion_planner/src/lerp_example.cpp
+++ b/doc/examples/creating_moveit_plugins/lerp_motion_planner/src/lerp_example.cpp
@@ -40,7 +40,7 @@
 
 #include <pluginlib/class_loader.h>
 
-// MoveIt!
+// MoveIt
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>

--- a/doc/examples/hybrid_planning/hybrid_planning_tutorial.rst
+++ b/doc/examples/hybrid_planning/hybrid_planning_tutorial.rst
@@ -1,7 +1,7 @@
 Hybrid Planning
 ===============
 
-In this section, you will learn how to use  Moveit 2's *Hybrid Planning* feature.
+In this section, you will learn how to use  MoveIt 2's *Hybrid Planning* feature.
 
 Hybrid Planning enables you to (re)plan and execute robot motions online with MoveIt 2 and to add more planning logic into your robot's motion planning pipeline.
 
@@ -90,7 +90,7 @@ To include the Hybrid Planning Architecture into you project you need to add a *
 
 Customizing the Hybrid Planning Architecture
 --------------------------------------------
-As the rest of Moveit 2, the *Hybrid Planning Architecture* is designed to be highly customizable while also offering the possibility to easily re-use existing solutions. Each of the architecture's components is a ROS 2 node and can be completely replaced by your own custom ROS 2 node as long as it offers the API required by the other nodes. Each component's runtime behavior is defined by plugins. This section focuses on the customization of the *Hybrid Planning Architecture* by implementing your own plugins.
+As the rest of MoveIt 2, the *Hybrid Planning Architecture* is designed to be highly customizable while also offering the possibility to easily re-use existing solutions. Each of the architecture's components is a ROS 2 node and can be completely replaced by your own custom ROS 2 node as long as it offers the API required by the other nodes. Each component's runtime behavior is defined by plugins. This section focuses on the customization of the *Hybrid Planning Architecture* by implementing your own plugins.
 
 Global and Local Motion Planning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/examples/hybrid_planning/hybrid_planning_tutorial.rst
+++ b/doc/examples/hybrid_planning/hybrid_planning_tutorial.rst
@@ -1,7 +1,7 @@
 Hybrid Planning
 ===============
 
-In this section, you will learn how to use  MoveIt 2's *Hybrid Planning* feature.
+In this section, you will learn how to use MoveIt 2's *Hybrid Planning* feature.
 
 Hybrid Planning enables you to (re)plan and execute robot motions online with MoveIt 2 and to add more planning logic into your robot's motion planning pipeline.
 

--- a/doc/examples/jupyter_notebook_prototyping/jupyter_notebook_prototyping_tutorial.rst
+++ b/doc/examples/jupyter_notebook_prototyping/jupyter_notebook_prototyping_tutorial.rst
@@ -16,7 +16,7 @@ The code for this tutorial can be found `here <https://github.com/peterdavidfaga
 
 Getting Started
 ---------------
-To complete this tutorial, you must have set up a colcon workspace that includes MoveIt2 and its corresponding tutorials. An excellent outline on how to set up such a workspace is provided in the :doc:`Getting Started Guide </doc/tutorials/getting_started/getting_started>`.
+To complete this tutorial, you must have set up a colcon workspace that includes MoveIt 2 and its corresponding tutorials. An excellent outline on how to set up such a workspace is provided in the :doc:`Getting Started Guide </doc/tutorials/getting_started/getting_started>`.
 
 Once you have set up your workspace, you can execute the code for this tutorial by running the following command (the servo section of this tutorial requires a PS4 Dualshock, if you don't have one consider setting this parameter to false): ::
 

--- a/doc/examples/jupyter_notebook_prototyping/src/moveit_notebook_tutorial.ipynb
+++ b/doc/examples/jupyter_notebook_prototyping/src/moveit_notebook_tutorial.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Introduction\n",
     "\n",
-    "Welcome to this tutorial on using jupyter notebooks with Moveit 2. A great benefit of being able to interact with MoveIt via a Python notebook is the ability to rapidly prototype code. We hope you find this interface intuitive and that you gain value from using MoveIt via Python notebooks.\n",
+    "Welcome to this tutorial on using jupyter notebooks with MoveIt 2. A great benefit of being able to interact with MoveIt via a Python notebook is the ability to rapidly prototype code. We hope you find this interface intuitive and that you gain value from using MoveIt via Python notebooks.\n",
     "\n",
     "In this tutorial we will cover the following: \n",
     "\n",

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -27,7 +27,7 @@ If you haven't already done so, make sure you've completed the steps in :doc:`Ge
 Design overview
 ---------------
 
-Moveit Servo consists of two main parts: The core implementation ``Servo`` which provides a C++ interface, and the ``ServoNode`` which
+MoveIt Servo consists of two main parts: The core implementation ``Servo`` which provides a C++ interface, and the ``ServoNode`` which
 wraps the C++ interface and provides a ROS interface.The configuration of Servo is done through ROS parameters specified in :moveit_codedir:`servo_parameters.yaml <moveit_ros/moveit_servo/config/servo_parameters.yaml>`
 
 In addition to the servoing capability, MoveIt Servo has some convenient features such as:

--- a/doc/examples/time_parameterization/time_parameterization_tutorial.rst
+++ b/doc/examples/time_parameterization/time_parameterization_tutorial.rst
@@ -20,7 +20,7 @@ MoveIt can support different algorithms for post-processing a kinematic trajecto
 
 * :moveit_codedir:`Time-optimal Trajectory Generation<moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp>`
 
-Time-optimal Trajectory Generation (TOTG) was introduced in PRs `#809 <https://github.com/ros-planning/moveit/pull/809>`_ and `#1365 <https://github.com/ros-planning/moveit/pull/1365>`_. It produces trajectories with very smooth and continuous velocity profiles. The method is based on fitting path segments to the original trajectory and then sampling new waypoints from the optimized path. This is different from strict time parameterization methods as resulting waypoints may divert from the original trajectory within a certain tolerance. As a consequence, additional collision checks might be required when using this method. It is the default everywhere in MoveIt2.
+Time-optimal Trajectory Generation (TOTG) was introduced in PRs `#809 <https://github.com/ros-planning/moveit/pull/809>`_ and `#1365 <https://github.com/ros-planning/moveit/pull/1365>`_. It produces trajectories with very smooth and continuous velocity profiles. The method is based on fitting path segments to the original trajectory and then sampling new waypoints from the optimized path. This is different from strict time parameterization methods as resulting waypoints may divert from the original trajectory within a certain tolerance. As a consequence, additional collision checks might be required when using this method. It is the default everywhere in MoveIt 2.
 
 Usage of a time parameterization algorithm as a Planning Request Adapter is documented in `this tutorial <../motion_planning_pipeline/motion_planning_pipeline_tutorial.html#using-a-planning-request-adapter>`_.
 

--- a/doc/how_to_guides/controller_teleoperation/controller_teleoperation.rst
+++ b/doc/how_to_guides/controller_teleoperation/controller_teleoperation.rst
@@ -21,7 +21,7 @@ Requirements
 Steps
 -----
 
-1. Build the MoveIt2 workspace
+1. Build the MoveIt 2 workspace
 
   First, ``cd`` to the root directory of the moveit2 workspace. (if you followed the :doc:`Getting Started </doc/tutorials/getting_started/getting_started>` tutorial, this will be ``~/ws_moveit/``).
 

--- a/doc/how_to_guides/isaac_panda/.docker/ros_entrypoint.sh
+++ b/doc/how_to_guides/isaac_panda/.docker/ros_entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Source ROS and the MoveIt2 workspace
+# Source ROS and the MoveIt 2 workspace
 source /opt/ros/humble/setup.bash
 source /root/ws_moveit/install/setup.bash
 echo "Sourced ROS & MoveIt Humble"

--- a/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.rst
+++ b/doc/how_to_guides/isaac_panda/isaac_panda_tutorial.rst
@@ -71,7 +71,7 @@ Computer Setup
 
 1. Install `Isaac Sim <https://docs.omniverse.nvidia.com/isaacsim/latest/installation/install_workstation.html>`_.
 
-2. Perform a shallow clone of the MoveIt2 Tutorials repo.
+2. Perform a shallow clone of the MoveIt 2 Tutorials repo.
 
 .. code-block:: bash
 


### PR DESCRIPTION
We have some misspelled MoveIt occurrences in the tutorials. https://github.com/ros-planning/moveit/pull/2692 has a nice check that tries to catch these. This PR brings in that check and fixes the misspellings.

Maintain the exception for non-words characters in https://github.com/ros-planning/moveit/pull/2692 to prevent failures due to class names like MoveitCpp.

This PR also augments that check for MoveIt 2 so we [respect the space](https://moveit.ros.org/about/press_kit/).
