### PR TITLE
Build collision scene example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endforeach()
 include_directories(${THIS_PACKAGE_INCLUDE_DIRS})
 
 # add_subdirectory(doc/examples/bullet_collision_checker)
-# add_subdirectory(doc/examples/collision_environments)
+add_subdirectory(doc/examples/collision_environments)
 # add_subdirectory(doc/examples/controller_configuration)
 # add_subdirectory(doc/examples/creating_moveit_plugins/lerp_motion_planner)
 # add_subdirectory(doc/examples/interactivity)


### PR DESCRIPTION
### Description

Currently, the collision_environments subdirectory (which contains the collision scene example) isn't being built. The collision scene example is used in the [CHOMP tutorial](https://moveit.picknik.ai/main/doc/how_to_guides/chomp_planner/chomp_planner_tutorial.html), which asks the user to run: `ros2 run moveit2_tutorials collision_scene_example`.

Current behaviour:
```bash
$ ros2 run moveit2_tutorials collision_scene_example         
No executable found
```

Expected behaviour after fix:
```bash
$ ros2 run moveit2_tutorials collision_scene_example         
```
The above command should not produce the `No executable found` output. Instead, you should see some boxes in the collision environment. Here's what it looks like when running through the tutorial:
![image](https://github.com/ros-planning/moveit2_tutorials/assets/10466537/6dbdc4a1-f8a4-4c96-aa48-52c23956a550)
