### PR TITLE
Upgrade the version of ruby used in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3'
 
     - name: Run htmlproofer.sh
       shell: bash


### PR DESCRIPTION
### Description

CI seems to be failing because we are using an old version of ruby that our dependencies for htmlprofer no longer support. Locally, on Ubuntu 22.04, the version of ruby I have that works is 3 so I am trying to set the version in CI to 3 to see if it fixes it.