### PR TITLE
Update sphinx version for CI to pass on main

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -58,7 +58,7 @@ release = ""
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip
-docutils==0.18.0
+docutils==0.18.1
 sphinx>=5.0.0
 sphinx-tabs==3.4.4
 sphinx-multiversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip
 docutils==0.16
 sphinx>=5.0.0
-sphinx-tabs
+sphinx-tabs==3.4.4
 sphinx-multiversion
 sphinx-rtd-theme
 sphinx-copybutton

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip
-docutils==0.16
+docutils==0.18.0
 sphinx>=5.0.0
 sphinx-tabs==3.4.4
 sphinx-multiversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip
 docutils==0.16
-sphinx
+sphinx>=5.0.0
 sphinx-tabs
 sphinx-multiversion
 sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip
 docutils==0.16
-sphinx==4.3.2
+sphinx
 sphinx-tabs
 sphinx-multiversion
 sphinx-rtd-theme


### PR DESCRIPTION
Currently, the `htmlproofer` and `upload_site_artifacts` CI jobs are failing on main due to 
```
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```
