### PR TITLE
Use branch name for checkout in site artifacts jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: 'main'
+        ref: ${{ matrix.rosdistro }}
 
     - name: Install Python dependencies
       run: |


### PR DESCRIPTION
### Description

Trying some changes to CI to see if it makes the `upload_site_artifacts` and `collate_site_artifacts` jobs pass.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
