### PR TITLE
[Test] Fix CI

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -131,6 +131,8 @@ templates_path = [
     "_templates",
 ]
 
+autodoc_mock_imports = ["moveit"]
+
 # smv_tag_whitelist = None
 
 smv_branch_whitelist = r"^(main|humble)$"

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -29,7 +29,7 @@ rm -rf moveit2
 popd
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
-sphinx-build -w -b html . build/html
+sphinx-build -b html . build/html
 
 # Replace Edit on Github links with local file paths
 grep -rl 'https:\/\/github.com\/ros-planning\/moveit2_tutorials\/blob\/main\/' ./build/ | \

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -29,7 +29,7 @@ rm -rf moveit2
 popd
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
-sphinx-build -W -b html . build/html
+sphinx-build -w -b html . build/html
 
 # Replace Edit on Github links with local file paths
 grep -rl 'https:\/\/github.com\/ros-planning\/moveit2_tutorials\/blob\/main\/' ./build/ | \


### PR DESCRIPTION
Error in CI
```
Extension error (sphinx.ext.autosummary):
Handler <function process_generate_options at 0x7f8546eb5750> for event 'builder-inited' threw an exception (exception: no module named moveit.core)
```

Potential solution - https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports
