### PR TITLE
Ignore MoveIt and MoveIt Core Packages from docs Imports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: 'main'
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,8 +56,6 @@ jobs:
       image: ${{ matrix.container }}
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: 'main'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
         cache: 'pip'
 
     - name: Install Python dependencies
@@ -108,7 +108,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3'
 
     # TODO (peterdavidfagan): don't hardcode branches for downloads
     - name: Download Rolling Artifacts

--- a/conf.py
+++ b/conf.py
@@ -254,14 +254,6 @@ extlinks = {
 doxylink = {"cpp_api": ("build/html/api/MoveIt.tag", "api/html")}
 add_function_parentheses = True
 
-try:
-    import moveit
-except Exception as e:
-    autodoc_mock_imports = ["moveit",
-                            "moveit.core",
-                            "moveit.planning",
-                            "moveit.servo_client"]
-
 autodoc_typehints = "signature"
 
 autodoc_default_options = {

--- a/conf.py
+++ b/conf.py
@@ -254,6 +254,17 @@ extlinks = {
 doxylink = {"cpp_api": ("build/html/api/MoveIt.tag", "api/html")}
 add_function_parentheses = True
 
+# Needed to support previous versions that did not include python bindings
+try:
+    import moveit
+except Exception as e:
+    autodoc_mock_imports = [
+        "moveit",
+        "moveit.core",
+        "moveit.planning",
+        "moveit.servo_client",
+    ]
+
 autodoc_typehints = "signature"
 
 autodoc_default_options = {

--- a/conf.py
+++ b/conf.py
@@ -131,6 +131,8 @@ templates_path = [
     "_templates",
 ]
 
+autodoc_mock_imports = ["moveit", "moveit.core"]
+
 # smv_tag_whitelist = None
 
 smv_branch_whitelist = r"^(main|humble)$"

--- a/conf.py
+++ b/conf.py
@@ -131,8 +131,6 @@ templates_path = [
     "_templates",
 ]
 
-autodoc_mock_imports = ["moveit", "moveit.core"]
-
 # smv_tag_whitelist = None
 
 smv_branch_whitelist = r"^(main|humble)$"
@@ -256,6 +254,13 @@ extlinks = {
 doxylink = {"cpp_api": ("build/html/api/MoveIt.tag", "api/html")}
 add_function_parentheses = True
 
+try:
+    import moveit
+except Exception as e:
+    autodoc_mock_imports = ["moveit",
+                            "moveit.core",
+                            "moveit.planning",
+                            "moveit.servo_client"]
 
 autodoc_typehints = "signature"
 


### PR DESCRIPTION
### Description

I think @Abishalini was on the right track with https://github.com/ros-planning/moveit2_tutorials/pull/857, we may just need to explicitly exclude the core package under moveit.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
