### PR TITLE
Backport docs CI fixes from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,9 +136,9 @@ jobs:
     # TODO(henningkayser): fix hack for using python api artifact in multiversion
     - name: Build multiversion
       run: |
-        cp build/html/main/doc/api/python_api/api.html .   # backup artifact html
+        cp -r build/html/main/doc/api/python_api/ .   # backup artifact html
         make multiversion
-        cp -f api.html build/html/main/doc/api/python_api/ # restore artifact html
+        cp -rf python_api/ build/html/main/doc/api/   # restore artifact html
 
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,6 @@ jobs:
       image: ${{ matrix.container }}
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: 'main'
 
     - name: Install Python dependencies
       run: |
@@ -89,11 +87,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: 'main'
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
         cache: 'pip'
 
     - name: Install Python dependencies
@@ -106,7 +103,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3'
 
     # TODO (peterdavidfagan): don't hardcode branches for downloads
     - name: Download Rolling Artifacts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,8 @@ jobs:
       image: ${{ matrix.container }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: 'main'
 
     - name: Install Python dependencies
       run: |
@@ -87,6 +89,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: 'main'
 
     - uses: actions/setup-python@v4
       with:

--- a/conf.py
+++ b/conf.py
@@ -251,6 +251,16 @@ extlinks = {
 doxylink = {"cpp_api": ("build/html/api/MoveIt.tag", "api/html")}
 add_function_parentheses = True
 
+# Needed to support previous versions that did not include python bindings
+try:
+    import moveit
+except Exception as e:
+    autodoc_mock_imports = [
+        "moveit",
+        "moveit.core",
+        "moveit.planning",
+        "moveit.servo_client",
+    ]
 
 class RedirectFrom(Directive):
 

--- a/conf.py
+++ b/conf.py
@@ -262,6 +262,7 @@ except Exception as e:
         "moveit.servo_client",
     ]
 
+
 class RedirectFrom(Directive):
 
     has_content = True


### PR DESCRIPTION
This PR backports (most of) https://github.com/ros-planning/moveit2_tutorials/pull/859 and https://github.com/ros-planning/moveit2_tutorials/pull/860 to fix humble docs build in CI.