### PR TITLE
Hightlighting differences between various installation instructions

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -27,6 +27,8 @@ Note to source the version of ROS you installed.  ::
 
 .. note:: Unlike ROS 1 setup scripts, in ROS 2 the setup scripts do not attempt to switch what version of ROS you are using.  This means that if you have previously sourced a different version of ROS, including from within your ``.bashrc`` file, you will run into errors during the building step.  To fix this change what is sourced in your ``.bashrc`` and start a new terminal.
 
+.. note:: If you are coming from the main page `Moveit2 Source Build <https://moveit.ros.org/install-moveit2/source/>`_, you may need to delete your .cache and /ws_moveit2 folder that you built Moveit in. Otherwise you may get weird namespace collision warnings.
+
 Install `rosdep <http://wiki.ros.org/rosdep>`_ to install system dependencies : ::
 
   sudo apt install python3-rosdep


### PR DESCRIPTION
[Disclaimer: I am a beginner, so feel free to reject this pull request.]

I built Moveit2 using the main page and then the getting started instructions and got weird namespace collision issues. These were fixed once I delete my cache and moveit2 workspace and rebuilt Moveit2 only using the Getting started tutorial. But that may just be because I am a beginner.

The headbanging against the namespace collision can be seen here:
https://robotics.stackexchange.com/questions/110079/rviz-crashes-during-moveit-quickstart-in-rviz-tutorial-namespace-collision/110110#110110

I am happy to resubmit a pull request if this first attempt is not quite right. But I would need some guidance about what to change (i.e. maybe something about the Source Build instructions building in ws_moveit2/ and Getting Started instructions building in ws_moveit/ ...?). Anyways, just thought I would submit a pull request in case you think it is a useful note to make.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
