### PR TITLE
Update variables based on updated RViz Quickstart variable names

### DIFF
--- a/doc/tutorials/your_first_project/your_first_project.rst
+++ b/doc/tutorials/your_first_project/your_first_project.rst
@@ -139,7 +139,7 @@ In place of the comment that says "Next step goes here", add this code:
 
   // Create the MoveIt MoveGroup Interface
   using moveit::planning_interface::MoveGroupInterface;
-  auto move_group_interface = MoveGroupInterface(node, "manipulator");
+  auto move_group_interface = MoveGroupInterface(node, "panda_arm");
 
   // Set a target Pose
   auto const target_pose = []{
@@ -216,13 +216,13 @@ If it fails to find that within 10 seconds, it prints this error and terminates 
 The first thing we do is create the ``MoveGroupInterface``.
 This object will be used to interact with ``move_group``, which allows us to plan and execute trajectories.
 Note that this is the only mutable object that we create in this program.
-Another thing to take note of is the second argument to the ``MoveGroupInterface`` object we are creating here: ``"manipulator"``.
+Another thing to take note of is the second argument to the ``MoveGroupInterface`` object we are creating here: ``"panda_arm"``.
 That is the group of joints as defined in the robot description that we are going to operate on with this ``MoveGroupInterface``.
 
 .. code-block:: C++
 
   using moveit::planning_interface::MoveGroupInterface;
-  auto move_group_interface = MoveGroupInterface(node, "manipulator");
+  auto move_group_interface = MoveGroupInterface(node, "panda_arm");
 
 Then, we set our target pose and plan. Note that only the target pose is set (via ``setPoseTarget``).
 The starting pose is implicitly the position published by the joint state publisher, which could be changed using the


### PR DESCRIPTION
[Disclaimer: beginner. Just throwing out suggestions based on discrepancies (I think) I am seeing in the tutorials.]
In the quick start tutorial, manipulator became panda_arm. Based on:
https://github.com/ros-planning/moveit2_tutorials/pull/886


### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
